### PR TITLE
Enhance exception granularity

### DIFF
--- a/src/Ting/ConnectionPool.php
+++ b/src/Ting/ConnectionPool.php
@@ -25,6 +25,7 @@
 namespace CCMBenchmark\Ting;
 
 use CCMBenchmark\Ting\Driver\DriverInterface;
+use CCMBenchmark\Ting\Exceptions\ConnectionException;
 use CCMBenchmark\Ting\Logger\DriverLoggerInterface;
 
 class ConnectionPool implements ConnectionPoolInterface
@@ -82,12 +83,12 @@ class ConnectionPool implements ConnectionPoolInterface
      * @param $name
      * @param $database
      * @return DriverInterface
-     * @throws Exception
+     * @throws ConnectionException
      */
     public function master($name, $database)
     {
         if (isset($this->connectionConfig[$name]['master']) === false) {
-            throw new Exception('Connection not found: ' . $name);
+            throw new ConnectionException('Connection not found: ' . $name);
         }
         $config = $this->connectionConfig[$name]['master'];
         $driverClass = $this->connectionConfig[$name]['namespace'] . '\\Driver';
@@ -107,12 +108,12 @@ class ConnectionPool implements ConnectionPoolInterface
      * @param string $name
      * @param string $database
      * @return DriverInterface
-     * @throws Exception
+     * @throws ConnectionException
      */
     public function slave($name, $database)
     {
         if (isset($this->connectionConfig[$name]) === false) {
-            throw new Exception('Connection not found: ' . $name);
+            throw new ConnectionException('Connection not found: ' . $name);
         }
         $driverClass = $this->connectionConfig[$name]['namespace'] . '\\Driver';
 
@@ -215,12 +216,12 @@ class ConnectionPool implements ConnectionPoolInterface
     /**
      * @param string $name connection name
      * @return string
-     * @throws Exception
+     * @throws ConnectionException
      */
     public function getDriverClass($name)
     {
         if (isset($this->connectionConfig[$name]) === false) {
-            throw new Exception('Connection not found: ' . $name);
+            throw new ConnectionException('Connection not found: ' . $name);
         }
 
         return $this->connectionConfig[$name]['namespace'] . '\\Driver';

--- a/src/Ting/Driver/Mysqli/Driver.php
+++ b/src/Ting/Driver/Mysqli/Driver.php
@@ -31,7 +31,7 @@ use CCMBenchmark\Ting\Driver\DriverInterface;
 use CCMBenchmark\Ting\Driver\NeverConnectedException;
 use CCMBenchmark\Ting\Driver\QueryException;
 use CCMBenchmark\Ting\Exceptions\StatementException;
-use CCMBenchmark\Ting\Exceptions\TransationException;
+use CCMBenchmark\Ting\Exceptions\TransactionException;
 use CCMBenchmark\Ting\Logger\DriverLoggerInterface;
 use CCMBenchmark\Ting\Repository\CollectionInterface;
 
@@ -411,36 +411,36 @@ class Driver implements DriverInterface
     }
 
     /**
-     * @throws TransationException
+     * @throws TransactionException
      */
     public function startTransaction()
     {
         if ($this->transactionOpened === true) {
-            throw new TransationException('Cannot start another transaction');
+            throw new TransactionException('Cannot start another transaction');
         }
         $this->connection->begin_transaction();
         $this->transactionOpened = true;
     }
 
     /**
-     * @throws TransationException
+     * @throws TransactionException
      */
     public function commit()
     {
         if ($this->transactionOpened === false) {
-            throw new TransationException('Cannot commit no transaction');
+            throw new TransactionException('Cannot commit no transaction');
         }
         $this->connection->commit();
         $this->transactionOpened = false;
     }
 
     /**
-     * @throws TransationException
+     * @throws TransactionException
      */
     public function rollback()
     {
         if ($this->transactionOpened === false) {
-            throw new TransationException('Cannot rollback no transaction');
+            throw new TransactionException('Cannot rollback no transaction');
         }
         $this->connection->rollback();
         $this->transactionOpened = false;

--- a/src/Ting/Driver/NeverConnectedException.php
+++ b/src/Ting/Driver/NeverConnectedException.php
@@ -26,5 +26,4 @@ namespace CCMBenchmark\Ting\Driver;
 
 class NeverConnectedException extends Exception
 {
-
 }

--- a/src/Ting/Driver/Pgsql/Driver.php
+++ b/src/Ting/Driver/Pgsql/Driver.php
@@ -400,7 +400,7 @@ class Driver implements DriverInterface
 
     /**
      * Rollback the actual opened transaction
-     * @throws TransactionException()
+     * @throws TransactionException
      */
     public function rollback()
     {

--- a/src/Ting/Driver/Pgsql/Driver.php
+++ b/src/Ting/Driver/Pgsql/Driver.php
@@ -28,6 +28,9 @@ use CCMBenchmark\Ting\Driver\DriverInterface;
 use CCMBenchmark\Ting\Driver\Exception;
 use CCMBenchmark\Ting\Driver\NeverConnectedException;
 use CCMBenchmark\Ting\Driver\QueryException;
+use CCMBenchmark\Ting\Exceptions\DriverException;
+use CCMBenchmark\Ting\Exceptions\StatementException;
+use CCMBenchmark\Ting\Exceptions\TransationException;
 use CCMBenchmark\Ting\Logger\DriverLoggerInterface;
 use CCMBenchmark\Ting\Repository\CollectionInterface;
 
@@ -136,7 +139,7 @@ class Driver implements DriverInterface
     /**
      * @param string $charset
      * @return void
-     * @throws Exception
+     * @throws DriverException
      */
     public function setCharset($charset)
     {
@@ -145,7 +148,7 @@ class Driver implements DriverInterface
         }
 
         if (pg_set_client_encoding($this->connection, $charset) === -1) {
-            throw new Exception('Can\'t set charset ' . $charset . ' (' . pg_last_error($this->connection) . ')');
+            throw new DriverException('Can\'t set charset ' . $charset . ' (' . pg_last_error($this->connection) . ')');
         }
 
         $this->currentCharset = $charset;
@@ -166,7 +169,7 @@ class Driver implements DriverInterface
      * Connect the driver to the given database
      * @param string $database
      * @return $this
-     * @throws Exception
+     * @throws DriverException
      */
     public function setDatabase($database)
     {
@@ -178,7 +181,7 @@ class Driver implements DriverInterface
         $this->database = $database;
 
         if ($resource === false) {
-            throw new Exception('Connect Error: ' . $this->dsn . ' dbname=' . $database);
+            throw new DriverException('Connect Error: ' . $this->dsn . ' dbname=' . $database);
         }
         $this->connection = $resource;
 
@@ -371,12 +374,12 @@ class Driver implements DriverInterface
 
     /**
      * Start a transaction against the current connection
-     * @throws Exception
+     * @throws TransationException
      */
     public function startTransaction()
     {
         if ($this->transactionOpened === true) {
-            throw new Exception('Cannot start another transaction');
+            throw new TransationException('Cannot start another transaction');
         }
         pg_query($this->connection, 'BEGIN');
         $this->transactionOpened = true;
@@ -384,12 +387,12 @@ class Driver implements DriverInterface
 
     /**
      * Commit the transaction against the current connection
-     * @throws Exception
+     * @throws TransationException()
      */
     public function commit()
     {
         if ($this->transactionOpened === false) {
-            throw new Exception('Cannot commit no transaction');
+            throw new TransationException('Cannot commit no transaction');
         }
         pg_query($this->connection, 'COMMIT');
         $this->transactionOpened = false;
@@ -397,12 +400,12 @@ class Driver implements DriverInterface
 
     /**
      * Rollback the actual opened transaction
-     * @throws Exception
+     * @throws TransationException()
      */
     public function rollback()
     {
         if ($this->transactionOpened === false) {
-            throw new Exception('Cannot rollback no transaction');
+            throw new TransationException('Cannot rollback no transaction');
         }
         pg_query($this->connection, 'ROLLBACK');
         $this->transactionOpened = false;
@@ -452,12 +455,12 @@ class Driver implements DriverInterface
 
     /**
      * @param $statement
-     * @throws Exception
+     * @throws StatementException
      */
     public function closeStatement($statement)
     {
         if (isset($this->preparedQueries[$statement]) === false) {
-            throw new Exception('Cannot close non prepared statement');
+            throw new StatementException('Cannot close non prepared statement');
         }
         unset($this->preparedQueries[$statement]);
     }

--- a/src/Ting/Driver/Pgsql/Driver.php
+++ b/src/Ting/Driver/Pgsql/Driver.php
@@ -30,7 +30,7 @@ use CCMBenchmark\Ting\Driver\NeverConnectedException;
 use CCMBenchmark\Ting\Driver\QueryException;
 use CCMBenchmark\Ting\Exceptions\DriverException;
 use CCMBenchmark\Ting\Exceptions\StatementException;
-use CCMBenchmark\Ting\Exceptions\TransationException;
+use CCMBenchmark\Ting\Exceptions\TransactionException;
 use CCMBenchmark\Ting\Logger\DriverLoggerInterface;
 use CCMBenchmark\Ting\Repository\CollectionInterface;
 
@@ -374,12 +374,12 @@ class Driver implements DriverInterface
 
     /**
      * Start a transaction against the current connection
-     * @throws TransationException
+     * @throws TransactionException
      */
     public function startTransaction()
     {
         if ($this->transactionOpened === true) {
-            throw new TransationException('Cannot start another transaction');
+            throw new TransactionException('Cannot start another transaction');
         }
         pg_query($this->connection, 'BEGIN');
         $this->transactionOpened = true;
@@ -387,12 +387,12 @@ class Driver implements DriverInterface
 
     /**
      * Commit the transaction against the current connection
-     * @throws TransationException()
+     * @throws TransactionException()
      */
     public function commit()
     {
         if ($this->transactionOpened === false) {
-            throw new TransationException('Cannot commit no transaction');
+            throw new TransactionException('Cannot commit no transaction');
         }
         pg_query($this->connection, 'COMMIT');
         $this->transactionOpened = false;
@@ -400,12 +400,12 @@ class Driver implements DriverInterface
 
     /**
      * Rollback the actual opened transaction
-     * @throws TransationException()
+     * @throws TransactionException()
      */
     public function rollback()
     {
         if ($this->transactionOpened === false) {
-            throw new TransationException('Cannot rollback no transaction');
+            throw new TransactionException('Cannot rollback no transaction');
         }
         pg_query($this->connection, 'ROLLBACK');
         $this->transactionOpened = false;

--- a/src/Ting/Exceptions/ConfigException.php
+++ b/src/Ting/Exceptions/ConfigException.php
@@ -6,5 +6,4 @@ use CCMBenchmark\Ting\Exception;
 
 class ConfigException extends Exception
 {
-
 }

--- a/src/Ting/Exceptions/ConfigException.php
+++ b/src/Ting/Exceptions/ConfigException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace CCMBenchmark\Ting\Exceptions;
+
+use CCMBenchmark\Ting\Exception;
+
+class ConfigException extends Exception
+{
+
+}

--- a/src/Ting/Exceptions/ConnectionException.php
+++ b/src/Ting/Exceptions/ConnectionException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace CCMBenchmark\Ting\Exceptions;
+
+class ConnectionException extends DriverException
+{
+}

--- a/src/Ting/Exceptions/DatabaseException.php
+++ b/src/Ting/Exceptions/DatabaseException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace CCMBenchmark\Ting\Exceptions;
+
+use CCMBenchmark\Ting\Exception;
+
+class DatabaseException extends Exception
+{
+}

--- a/src/Ting/Exceptions/DatabaseException.php
+++ b/src/Ting/Exceptions/DatabaseException.php
@@ -2,7 +2,7 @@
 
 namespace CCMBenchmark\Ting\Exceptions;
 
-use CCMBenchmark\Ting\Exception;
+use CCMBenchmark\Ting\Driver\Exception;
 
 class DatabaseException extends Exception
 {

--- a/src/Ting/Exceptions/DriverException.php
+++ b/src/Ting/Exceptions/DriverException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace CCMBenchmark\Ting\Exceptions;
+
+use CCMBenchmark\Ting\Driver\Exception;
+
+class DriverException extends Exception
+{
+}

--- a/src/Ting/Exceptions/HydratorException.php
+++ b/src/Ting/Exceptions/HydratorException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace CCMBenchmark\Ting\Exceptions;
+
+use CCMBenchmark\Ting\Exception;
+
+class HydratorException extends Exception
+{
+}

--- a/src/Ting/Exceptions/IOException.php
+++ b/src/Ting/Exceptions/IOException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace CCMBenchmark\Ting\Exceptions;
+
+use CCMBenchmark\Ting\Exception;
+
+class IOException extends Exception
+{
+}

--- a/src/Ting/Exceptions/RepositoryException.php
+++ b/src/Ting/Exceptions/RepositoryException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace CCMBenchmark\Ting\Exceptions;
+
+use CCMBenchmark\Ting\Exception;
+
+class RepositoryException extends Exception
+{
+}

--- a/src/Ting/Exceptions/StatementException.php
+++ b/src/Ting/Exceptions/StatementException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace CCMBenchmark\Ting\Exceptions;
+
+class StatementException extends DriverException
+{
+}

--- a/src/Ting/Exceptions/SyntaxException.php
+++ b/src/Ting/Exceptions/SyntaxException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace CCMBenchmark\Ting\Exceptions;
+
+class SyntaxException extends ValueException
+{
+}

--- a/src/Ting/Exceptions/TransactionException.php
+++ b/src/Ting/Exceptions/TransactionException.php
@@ -2,6 +2,6 @@
 
 namespace CCMBenchmark\Ting\Exceptions;
 
-class TransationException extends DriverException
+class TransactionException extends DriverException
 {
 }

--- a/src/Ting/Exceptions/TransationException.php
+++ b/src/Ting/Exceptions/TransationException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace CCMBenchmark\Ting\Exceptions;
+
+class TransationException extends DriverException
+{
+}

--- a/src/Ting/Exceptions/ValueException.php
+++ b/src/Ting/Exceptions/ValueException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace CCMBenchmark\Ting\Exceptions;
+
+use CCMBenchmark\Ting\Exception;
+
+class ValueException extends Exception
+{
+}

--- a/src/Ting/Repository/HydratorRelational.php
+++ b/src/Ting/Repository/HydratorRelational.php
@@ -25,6 +25,7 @@
 namespace CCMBenchmark\Ting\Repository;
 
 use CCMBenchmark\Ting\Exception;
+use CCMBenchmark\Ting\Exceptions\HydratorException;
 use CCMBenchmark\Ting\Repository\Hydrator\Relation;
 use CCMBenchmark\Ting\Repository\Hydrator\RelationMany;
 
@@ -62,13 +63,13 @@ final class HydratorRelational extends Hydrator
 
     /**
      * @param bool $enable
-     * @throws Exception
+     * @throws HydratorException
      * @return void
      */
     public function identityMap($enable)
     {
         if ((bool) $enable === false) {
-            throw new Exception('identityMap can\'t be disabled for this Hydrator');
+            throw new HydratorException('identityMap can\'t be disabled for this Hydrator');
         }
     }
 
@@ -237,7 +238,7 @@ final class HydratorRelational extends Hydrator
      * @param string $table
      * @param object $entity
      *
-     * @throws Exception
+     * @throws HydratorException
      *
      * @return string
      */
@@ -249,7 +250,7 @@ final class HydratorRelational extends Hydrator
         }
 
         if ($id === '') {
-            throw new Exception(sprintf('No primary found for "%s"', $this->metadataList[$table]->getEntity()));
+            throw new HydratorException(sprintf('No primary found for "%s"', $this->metadataList[$table]->getEntity()));
         }
 
         return $id;

--- a/src/Ting/Repository/Metadata.php
+++ b/src/Ting/Repository/Metadata.php
@@ -28,6 +28,7 @@ use CCMBenchmark\Ting\Connection;
 use CCMBenchmark\Ting\ConnectionPoolInterface;
 use CCMBenchmark\Ting\Driver\DriverInterface;
 use CCMBenchmark\Ting\Exception;
+use CCMBenchmark\Ting\Exceptions\ConfigException;
 use CCMBenchmark\Ting\Exceptions\SyntaxException;
 use CCMBenchmark\Ting\Exceptions\ValueException;
 use CCMBenchmark\Ting\Query\Generator;
@@ -224,21 +225,21 @@ class Metadata
      *      columnName : string : name of the mysql column
      *      primary : boolean : is this field a primary - optional
      *      autoincrement : boolean : is this field an autoincrement - optional
-     * @throws ValueException
+     * @throws ConfigException
      * @return $this
      */
     public function addField(array $params)
     {
         if (isset($params['fieldName']) === false) {
-            throw new ValueException('Field configuration must have "fieldName" property');
+            throw new ConfigException('Field configuration must have "fieldName" property');
         }
 
         if (isset($params['columnName']) === false) {
-            throw new ValueException('Field configuration must have "columnName" property');
+            throw new ConfigException('Field configuration must have "columnName" property');
         }
 
         if (isset($params['type']) === false) {
-            throw new ValueException('Field configuration must have "type" property');
+            throw new ConfigException('Field configuration must have "type" property');
         }
 
         if (isset($params['primary']) === true && $params['primary'] === true) {

--- a/src/Ting/Repository/Metadata.php
+++ b/src/Ting/Repository/Metadata.php
@@ -129,7 +129,7 @@ class Metadata
      */
     public function setRepository($className)
     {
-        if ('\\' === ($className[0] ?? '')) {
+        if (($className[0] ?? '') === '\\') {
             throw new SyntaxException('Class must not start with a \\');
         }
 
@@ -156,7 +156,7 @@ class Metadata
      */
     public function setEntity($className)
     {
-        if ('\\' === ($className[0] ?? '')) {
+        if (($className[0] ?? '') === '\\') {
             throw new SyntaxException('Class must not start with a \\');
         }
 

--- a/src/Ting/Repository/Metadata.php
+++ b/src/Ting/Repository/Metadata.php
@@ -28,6 +28,8 @@ use CCMBenchmark\Ting\Connection;
 use CCMBenchmark\Ting\ConnectionPoolInterface;
 use CCMBenchmark\Ting\Driver\DriverInterface;
 use CCMBenchmark\Ting\Exception;
+use CCMBenchmark\Ting\Exceptions\SyntaxException;
+use CCMBenchmark\Ting\Exceptions\ValueException;
 use CCMBenchmark\Ting\Query\Generator;
 use CCMBenchmark\Ting\Query\PreparedQuery;
 use CCMBenchmark\Ting\Query\QueryFactoryInterface;
@@ -122,12 +124,12 @@ class Metadata
      * Set repository name
      * @param string $className
      * @return $this
-     * @throws \CCMBenchmark\Ting\Exception
+     * @throws SyntaxException
      */
     public function setRepository($className)
     {
-        if (substr($className, 0, 1) === '\\') {
-            throw new Exception('Class must not start with a \\');
+        if ('\\' === ($className[0] ?? '')) {
+            throw new SyntaxException('Class must not start with a \\');
         }
 
         $this->repository = (string) $className;
@@ -149,12 +151,12 @@ class Metadata
      * Set entity name
      * @param string $className
      * @return $this
-     * @throws \CCMBenchmark\Ting\Exception
+     * @throws SyntaxException
      */
     public function setEntity($className)
     {
-        if (substr($className, 0, 1) === '\\') {
-            throw new Exception('Class must not start with a \\');
+        if ('\\' === ($className[0] ?? '')) {
+            throw new SyntaxException('Class must not start with a \\');
         }
 
         $this->entity = (string) $className;
@@ -222,21 +224,21 @@ class Metadata
      *      columnName : string : name of the mysql column
      *      primary : boolean : is this field a primary - optional
      *      autoincrement : boolean : is this field an autoincrement - optional
-     * @throws \CCMBenchmark\Ting\Exception
+     * @throws ValueException
      * @return $this
      */
     public function addField(array $params)
     {
         if (isset($params['fieldName']) === false) {
-            throw new Exception('Field configuration must have "fieldName" property');
+            throw new ValueException('Field configuration must have "fieldName" property');
         }
 
         if (isset($params['columnName']) === false) {
-            throw new Exception('Field configuration must have "columnName" property');
+            throw new ValueException('Field configuration must have "columnName" property');
         }
 
         if (isset($params['type']) === false) {
-            throw new Exception('Field configuration must have "type" property');
+            throw new ValueException('Field configuration must have "type" property');
         }
 
         if (isset($params['primary']) === true && $params['primary'] === true) {
@@ -489,14 +491,14 @@ class Metadata
     /**
      * @param array $criteria
      * @return array
-     * @throws Exception
+     * @throws ValueException
      */
     protected function getColumnsFromCriteria(array $criteria)
     {
         $criteriaColumn = array();
         foreach ($criteria as $property => $value) {
             if (isset($this->fieldsByProperty[$property]) === false) {
-                throw new Exception(sprintf('Undefined property %s in your criteria', $property));
+                throw new ValueException(sprintf('Undefined property %s in your criteria', $property));
             }
             $column = $this->fieldsByProperty[$property]['columnName'];
             $criteriaColumn[$column] = $value;

--- a/src/Ting/Repository/MetadataCacheGenerator.php
+++ b/src/Ting/Repository/MetadataCacheGenerator.php
@@ -25,6 +25,7 @@
 namespace CCMBenchmark\Ting\Repository;
 
 use CCMBenchmark\Ting\Exception;
+use CCMBenchmark\Ting\Exceptions\IOException;
 
 class MetadataCacheGenerator
 {
@@ -43,7 +44,7 @@ class MetadataCacheGenerator
     /**
      * @param string $cacheDir
      * @param string $filename
-     * @throws Exception
+     * @throws IOException
      *
      * @internal
      */
@@ -56,10 +57,10 @@ class MetadataCacheGenerator
         }
 
         if (is_writable($this->cacheDir . '/') === false) {
-            throw new Exception('Cache directory for Metadata is not writable: ' . $cacheDir);
+            throw new IOException('Cache directory for Metadata is not writable: ' . $cacheDir);
         }
         if (touch($this->getFileName()) === false) {
-            throw new Exception('Cache file for Metadata is not writable: ' . $this->getFileName());
+            throw new IOException('Cache file for Metadata is not writable: ' . $this->getFileName());
         }
     }
 

--- a/src/Ting/Repository/Repository.php
+++ b/src/Ting/Repository/Repository.php
@@ -33,7 +33,8 @@ use CCMBenchmark\Ting\Driver\Mysqli;
 use CCMBenchmark\Ting\Driver\NeverConnectedException;
 use CCMBenchmark\Ting\Driver\Pgsql;
 use CCMBenchmark\Ting\Driver\SphinxQL;
-use CCMBenchmark\Ting\Exception;
+use CCMBenchmark\Ting\Exceptions\DriverException;
+use CCMBenchmark\Ting\Exceptions\RepositoryException;
 use CCMBenchmark\Ting\MetadataRepository;
 use CCMBenchmark\Ting\Query\QueryFactory;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
@@ -127,7 +128,7 @@ abstract class Repository
                 $this->metadata = $metadata;
             },
             function () use ($class) {
-                throw new Exception(
+                throw new RepositoryException(
                     'Metadata not found for ' . $class
                     . ', you probably forgot to call MetadataRepository::batchLoadMetadata'
                 );
@@ -197,7 +198,7 @@ abstract class Repository
     /**
      * @param string $type One of the QUERY_ constant
      * @return QueryInterface
-     * @throws Exception
+     * @throws DriverException
      */
     public function getQueryBuilder($type)
     {
@@ -214,7 +215,7 @@ abstract class Repository
                 $queryFactory = new AuraQueryFactory('mysql');
                 break;
             default:
-                throw new Exception('Driver ' . $driver . ' is unknown to build QueryBuilder');
+                throw new DriverException('Driver ' . $driver . ' is unknown to build QueryBuilder');
         }
 
         switch ($type) {

--- a/src/Ting/UnitOfWork.php
+++ b/src/Ting/UnitOfWork.php
@@ -338,7 +338,7 @@ class UnitOfWork implements PropertyListenerInterface
                 unset($this->entitiesShouldBePersisted[$uuid]);
             },
             function () use ($entity) {
-                throw new Exception('Could not find repository matching entity "' . get_class($entity) . '"');
+                throw new QueryException('Could not find repository matching entity "' . get_class($entity) . '"');
             }
         );
     }
@@ -374,7 +374,7 @@ class UnitOfWork implements PropertyListenerInterface
                 $this->manage($entity);
             },
             function () use ($entity) {
-                throw new Exception('Could not find repository matching entity "' . get_class($entity) . '"');
+                throw new QueryException('Could not find repository matching entity "' . get_class($entity) . '"');
             }
         );
     }
@@ -413,7 +413,7 @@ class UnitOfWork implements PropertyListenerInterface
                 $this->detach($entity);
             },
             function () use ($entity) {
-                throw new Exception('Could not find repository matching entity "' . get_class($entity) . '"');
+                throw new QueryException('Could not find repository matching entity "' . get_class($entity) . '"');
             }
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0

Adding new exceptions to enhance the catching granularity.
All the new exceptions extend the `CCMBenchmark\Ting\Exception` class, so the existing code should continue working as expected.

In the future, it would be nice to move the already existing exceptions to the new `CCMBenchmark\Ting\Exceptions` namespace. This way, all the exceptions would live in the same folder, which would make the project more clean (but this would also lead to a BC break, doh!).