### PR TITLE
Fix return type-hint deprecations

### DIFF
--- a/src/Ting/Cache/Cache.php
+++ b/src/Ting/Cache/Cache.php
@@ -86,6 +86,8 @@ class Cache implements CacheInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function delete($id)
     {
@@ -98,6 +100,8 @@ class Cache implements CacheInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function fetch($id)
     {
@@ -110,6 +114,8 @@ class Cache implements CacheInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function contains($id)
     {
@@ -122,6 +128,8 @@ class Cache implements CacheInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
     public function save($id, $data, $lifeTime = 0)
     {
@@ -134,6 +142,8 @@ class Cache implements CacheInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return array|null
      */
     public function getStats()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0


Fix:
```
[info] User Deprecated: Method "Doctrine\Common\Cache\Cache::delete()" might add "bool" as a native return type declaration in the future. Do the same in implementation "CCMBenchmark\Ting\Cache\Cache" now to avoid errors or add an explicit @return annotation to suppress this message.

[info] User Deprecated: Method "Doctrine\Common\Cache\Cache::fetch()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "CCMBenchmark\Ting\Cache\Cache" now to avoid errors or add an explicit @return annotation to suppress this message.

[info] User Deprecated: Method "Doctrine\Common\Cache\Cache::contains()" might add "bool" as a native return type declaration in the future. Do the same in implementation "CCMBenchmark\Ting\Cache\Cache" now to avoid errors or add an explicit @return annotation to suppress this message.

[info] User Deprecated: Method "Doctrine\Common\Cache\Cache::save()" might add "bool" as a native return type declaration in the future. Do the same in implementation "CCMBenchmark\Ting\Cache\Cache" now to avoid errors or add an explicit @return annotation to suppress this message.

[info] User Deprecated: Method "Doctrine\Common\Cache\Cache::getStats()" might add "?array" as a native return type declaration in the future. Do the same in implementation "CCMBenchmark\Ting\Cache\Cache" now to avoid errors or add an explicit @return annotation to suppress this message.
```