### PR TITLE
Fix MetadataRepository::batchLoadMetadata() loading abstract repositories and interfaces

### DIFF
--- a/tests/fixtures/model/AbstractRepository.php
+++ b/tests/fixtures/model/AbstractRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace tests\fixtures\model;
+
+use CCMBenchmark\Ting\Repository\MetadataInitializer;
+
+abstract class AbstractRepository implements MetadataInitializer
+{
+    // This abstract class is just here to validate it is not loaded by the MetadataRepository::batchLoadMetadata() method.
+}

--- a/tests/fixtures/model/BouhReadOnlyRepository.php
+++ b/tests/fixtures/model/BouhReadOnlyRepository.php
@@ -29,7 +29,7 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 use CCMBenchmark\Ting\Repository\Repository;
 
-class BouhRepository extends Repository implements MetadataInitializer
+class BouhReadOnlyRepository extends Repository implements MetadataInitializer
 {
     public static $options;
 

--- a/tests/fixtures/model/Repository.php
+++ b/tests/fixtures/model/Repository.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace tests\fixtures\model;
+
+interface Repository
+{
+    // This interface is just here to validate it is not loaded by the MetadataRepository::batchLoadMetadata() method.
+}

--- a/tests/units/Ting/MetadataRepository.php
+++ b/tests/units/Ting/MetadataRepository.php
@@ -251,18 +251,17 @@ class MetadataRepository extends atoum
     public function testBatchLoadMetadataShouldLoad5Repositories()
     {
         $services = new \CCMBenchmark\Ting\Services();
-        $test = $this
+        $this
             ->if(
                 $metadataRepository = new \CCMBenchmark\Ting\MetadataRepository(
                     $services->get('SerializerFactory')
                 )
             )
-            ->array($data = $metadataRepository->batchLoadMetadata(
+            ->array($metadataRepository->batchLoadMetadata(
                 'tests\fixtures\model',
                 __DIR__ . '/../../fixtures/model/*Repository.php'
-            ));
-
-            $test->isIdenticalTo([
+            ))
+            ->isIdenticalTo([
                 'tests\fixtures\model\BouhMySchemaRepository' => 'tests\fixtures\model\BouhMySchemaRepository',
                 'tests\fixtures\model\BouhReadOnlyRepository' => 'tests\fixtures\model\BouhReadOnlyRepository',
                 'tests\fixtures\model\BouhRepository'         => 'tests\fixtures\model\BouhRepository',

--- a/tests/units/Ting/MetadataRepository.php
+++ b/tests/units/Ting/MetadataRepository.php
@@ -251,23 +251,25 @@ class MetadataRepository extends atoum
     public function testBatchLoadMetadataShouldLoad5Repositories()
     {
         $services = new \CCMBenchmark\Ting\Services();
-        $this
+        $test = $this
             ->if(
                 $metadataRepository = new \CCMBenchmark\Ting\MetadataRepository(
                     $services->get('SerializerFactory')
                 )
             )
-            ->array($metadataRepository->batchLoadMetadata(
+            ->array($data = $metadataRepository->batchLoadMetadata(
                 'tests\fixtures\model',
                 __DIR__ . '/../../fixtures/model/*Repository.php'
-            ))
-                ->isIdenticalTo([
-                    'tests\fixtures\model\BouhMySchemaRepository' => 'tests\fixtures\model\BouhMySchemaRepository',
-                    'tests\fixtures\model\BouhRepository'         => 'tests\fixtures\model\BouhRepository',
-                    'tests\fixtures\model\CityRepository'         => 'tests\fixtures\model\CityRepository',
-                    'tests\fixtures\model\CitySecondRepository'   => 'tests\fixtures\model\CitySecondMetadataRepository',
-                    'tests\fixtures\model\ParkRepository'         => 'tests\fixtures\model\ParkRepository'
-                ]);
+            ));
+
+            $test->isIdenticalTo([
+                'tests\fixtures\model\BouhMySchemaRepository' => 'tests\fixtures\model\BouhMySchemaRepository',
+                'tests\fixtures\model\BouhReadOnlyRepository' => 'tests\fixtures\model\BouhReadOnlyRepository',
+                'tests\fixtures\model\BouhRepository'         => 'tests\fixtures\model\BouhRepository',
+                'tests\fixtures\model\CityRepository'         => 'tests\fixtures\model\CityRepository',
+                'tests\fixtures\model\CitySecondRepository'   => 'tests\fixtures\model\CitySecondMetadataRepository',
+                'tests\fixtures\model\ParkRepository'         => 'tests\fixtures\model\ParkRepository',
+            ]);
     }
 
     public function testBatchLoadMetadataWithInvalidPathShouldReturnEmptyArray()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets | Ø

We might want to make our repositories extend an abstract class to provide some useful methods. In this case, the metadata loading will try to initialize it. Eventually, it will fail because abstract classes are not meant to be used without an implementation.

This PR fixes this behavior by ensuring only the non-abstract classes are initialized.