### PR TITLE
Fix boolean values support in prepared query

### DIFF
--- a/src/Ting/Driver/Mysqli/Driver.php
+++ b/src/Ting/Driver/Mysqli/Driver.php
@@ -272,7 +272,7 @@ class Driver implements DriverInterface
             '/' . $this->parameterMatching . '/',
             function ($match) use ($params) {
                 if (!array_key_exists($match[1], $params)) {
-                    throw new QueryException('Value has not been setted for param ' . $match[1]);
+                    throw new QueryException('Value has not been set for param ' . $match[1]);
                 }
 
                 return $this->quoteValue($params[$match[1]]);
@@ -313,14 +313,14 @@ class Driver implements DriverInterface
     protected function quoteValue($value)
     {
         switch (gettype($value)) {
+            case "boolean":
+                return (int) $value;
             case "integer":
-                // integer and double doesn't need quotes
+                // integer and double don't need quotes
             case "double":
                 return $value;
-                break;
             default:
                 return '"' . $this->connection->real_escape_string($value) . '"';
-                break;
         }
     }
 

--- a/tests/units/Ting/Driver/Mysqli/Driver.php
+++ b/tests/units/Ting/Driver/Mysqli/Driver.php
@@ -371,14 +371,14 @@ class Driver extends atoum
             ->if($driver = new \CCMBenchmark\Ting\Driver\Mysqli\Driver($driverFake))
             ->exception(function () use ($driver) {
                 $driver->execute("SELECT 'Bouh:Ting', ' ::Ting', ADDTIME('23:59:59', '1:1:1') '
-                . ' FROM Bouh WHERE id = :id AND login = :login",
-                    ['id' => 3, 'login' => 'Sylvain']);
+                . ' FROM Bouh WHERE id = :id AND login = :login AND is_banned = :is_banned",
+                    ['id' => 3, 'login' => 'Sylvain', 'is_banned' => false]);
             })
                 ->hasCode(0)
             ->mock($driverFake)
                 ->call('query')
                     ->withIdenticalArguments("SELECT 'Bouh:Ting', ' ::Ting', ADDTIME('23:59:59', '1:1:1') '
-                . ' FROM Bouh WHERE id = 3 AND login = \"Sylvain\"")
+                . ' FROM Bouh WHERE id = 3 AND login = \"Sylvain\" AND is_banned = 0")
                         ->once();
     }
 

--- a/tests/units/Ting/Driver/Mysqli/Statement.php
+++ b/tests/units/Ting/Driver/Mysqli/Statement.php
@@ -38,9 +38,10 @@ class Statement extends atoum
             'id'          => 3,
             'old'         => 32.1,
             'description' => 'A very long description',
-            'date' => '2014-03-01 14:02:05'
+            'date'        => '2014-03-01 14:02:05',
+            'is_banned'   => false,
         );
-        $paramsOrder = array('firstname' => null, 'id' => null, 'description' => null, 'old' => null, 'date' => null);
+        $paramsOrder = array('firstname' => null, 'id' => null, 'description' => null, 'old' => null, 'date' => null, 'is_banned' => null);
 
         $this->calling($driverStatement)->get_result = new \mock\Iterator();
         $driverStatement->errno = 0;
@@ -56,12 +57,13 @@ class Statement extends atoum
             ->mock($driverStatement)
                 ->call('bind_param')
                     ->withIdenticalArguments(
-                        'sisds',
+                        'sisdsi',
                         'Sylvain',
                         3,
                         'A very long description',
                         32.1,
-                        '2014-03-01 14:02:05'
+                        '2014-03-01 14:02:05',
+                        0
                     )->once();
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets | Ø

When executing prepared query on MySQL, the boolean values are currently converted to their string equivalent:

```php
php > var_dump((string) true);
string(1) "1"
php > var_dump((string) false);
string(0) ""
```

Especially for `false`, this leads to an SQL error, because MySQL doesn't expect an empty string for such value.
In this PR, we convert the boolean values to an integer in order to give MySQL 0 (== false) or 1 (== true).

**Important note:** this issue could have been avoided by using the [`mysqli_prepare()`](https://www.php.net/manual/fr/mysqli.prepare.php). Is there a reason for not using it in the first place?