### PR TITLE
Fix: boolean values support in non-prepared query

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+3.6.2 (2022-04-12):
+    * Fix: null values support in non-prepared query
+
 3.6.1 (2022-01-18):
     * Fix: boolean values support in prepared query #58 (thanks @Deuchnord)
 

--- a/src/Ting/Driver/Mysqli/Driver.php
+++ b/src/Ting/Driver/Mysqli/Driver.php
@@ -35,6 +35,8 @@ use CCMBenchmark\Ting\Exceptions\TransactionException;
 use CCMBenchmark\Ting\Logger\DriverLoggerInterface;
 use CCMBenchmark\Ting\Repository\CollectionInterface;
 
+use function is_null;
+
 class Driver implements DriverInterface
 {
 
@@ -319,6 +321,8 @@ class Driver implements DriverInterface
                 // integer and double don't need quotes
             case "double":
                 return $value;
+            case "NULL":
+                return 'null';
             default:
                 return '"' . $this->connection->real_escape_string($value) . '"';
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets | 