### PR TITLE
fix(hydratorRelational): sort config from source and target dependencies

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Unreleased:
+    * Fix: HydratorRelational hydration order when many nested entities
+
 3.7.2 (2023-10-23):
     * Make tests pass on PHP 8.1+
     * Allow access to list of managed entities
@@ -25,7 +28,7 @@
 
 3.5.7 (2020-08-28):
     * Fix: Revert Hydrator entity's reference calculation factorization [162f539]
-    * Fix: HydratorAggregator yield one time even when there is 0 result 
+    * Fix: HydratorAggregator yield one time even when there is 0 result
     * Fix: Query Generator use proper values
 
 3.5.6 (2019-10-02):
@@ -35,7 +38,7 @@
     * Merge back 3.4.3 and 3.4.4
 
 3.5.4 (2019-09-13):
-    * Fix: Result return from hydrator are identical when changing order of primary key field 
+    * Fix: Result return from hydrator are identical when changing order of primary key field
 
 3.5.3 (2019-07-24):
     * Fix: The timezone is now setted only on chang

--- a/tests/fixtures/model/Authority.php
+++ b/tests/fixtures/model/Authority.php
@@ -27,17 +27,11 @@ namespace tests\fixtures\model;
 use CCMBenchmark\Ting\Entity\NotifyProperty;
 use CCMBenchmark\Ting\Entity\NotifyPropertyInterface;
 
-class City implements NotifyPropertyInterface
+class Authority implements NotifyPropertyInterface
 {
-
     use NotifyProperty;
 
-    protected $id        = null;
-    protected $name      = null;
-    protected $zipcode   = null;
-    protected $bouhId    = null;
-    protected $parks     = [];
-    protected $department = null;
+    protected $id = null;
 
     public function setId($id)
     {
@@ -45,61 +39,8 @@ class City implements NotifyPropertyInterface
         $this->id = $id;
     }
 
-    public function setName($name)
-    {
-        $this->propertyChanged('name', $this->name, $name);
-        $this->name = $name;
-    }
-
-    public function setZipcode($zipcode)
-    {
-        $this->propertyChanged('zipcode', $this->zipcode, $zipcode);
-        $this->zipcode = (string) $zipcode;
-    }
-
-    public function setBouhId($bouhId)
-    {
-        $this->propertyChanged('bouhId', $this->bouhId, $bouhId);
-        $this->bouhId = (string) $bouhId;
-    }
-
     public function getId()
     {
         return $this->id;
-    }
-
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    public function getZipcode()
-    {
-        return $this->zipcode;
-    }
-
-    public function getBouhId()
-    {
-        return $this->bouhId;
-    }
-
-    public function parksAre(array $parks)
-    {
-        $this->parks = $parks;
-    }
-
-    public function getParks()
-    {
-        return $this->parks;
-    }
-
-    public function setDepartment(Department $department)
-    {
-        $this->department = $department;
-    }
-
-    public function getDepartment()
-    {
-        return $this->department;
     }
 }

--- a/tests/fixtures/model/AuthorityRepository.php
+++ b/tests/fixtures/model/AuthorityRepository.php
@@ -1,0 +1,31 @@
+<?php
+/***********************************************************************
+ *
+ * Ting - PHP Datamapper
+ * ==========================================
+ *
+ * Copyright (C) 2014 CCM Benchmark Group. (http://www.ccmbenchmark.com)
+ *
+ ***********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ **********************************************************************/
+
+namespace tests\fixtures\model;
+
+use CCMBenchmark\Ting\Repository\Repository;
+
+class AuthorityRepository extends Repository
+{
+}

--- a/tests/fixtures/model/Department.php
+++ b/tests/fixtures/model/Department.php
@@ -27,17 +27,13 @@ namespace tests\fixtures\model;
 use CCMBenchmark\Ting\Entity\NotifyProperty;
 use CCMBenchmark\Ting\Entity\NotifyPropertyInterface;
 
-class City implements NotifyPropertyInterface
+class Department implements NotifyPropertyInterface
 {
 
     use NotifyProperty;
 
-    protected $id        = null;
-    protected $name      = null;
-    protected $zipcode   = null;
-    protected $bouhId    = null;
-    protected $parks     = [];
-    protected $department = null;
+    protected $id = null;
+    protected $authority = null;
 
     public function setId($id)
     {
@@ -45,61 +41,18 @@ class City implements NotifyPropertyInterface
         $this->id = $id;
     }
 
-    public function setName($name)
-    {
-        $this->propertyChanged('name', $this->name, $name);
-        $this->name = $name;
-    }
-
-    public function setZipcode($zipcode)
-    {
-        $this->propertyChanged('zipcode', $this->zipcode, $zipcode);
-        $this->zipcode = (string) $zipcode;
-    }
-
-    public function setBouhId($bouhId)
-    {
-        $this->propertyChanged('bouhId', $this->bouhId, $bouhId);
-        $this->bouhId = (string) $bouhId;
-    }
-
     public function getId()
     {
         return $this->id;
     }
 
-    public function getName()
+    public function setAuthority(Authority $authority)
     {
-        return $this->name;
+        $this->authority = $authority;
     }
 
-    public function getZipcode()
+    public function getAuthority()
     {
-        return $this->zipcode;
-    }
-
-    public function getBouhId()
-    {
-        return $this->bouhId;
-    }
-
-    public function parksAre(array $parks)
-    {
-        $this->parks = $parks;
-    }
-
-    public function getParks()
-    {
-        return $this->parks;
-    }
-
-    public function setDepartment(Department $department)
-    {
-        $this->department = $department;
-    }
-
-    public function getDepartment()
-    {
-        return $this->department;
+        return $this->authority;
     }
 }

--- a/tests/fixtures/model/DepartmentRepository.php
+++ b/tests/fixtures/model/DepartmentRepository.php
@@ -1,0 +1,31 @@
+<?php
+/***********************************************************************
+ *
+ * Ting - PHP Datamapper
+ * ==========================================
+ *
+ * Copyright (C) 2014 CCM Benchmark Group. (http://www.ccmbenchmark.com)
+ *
+ ***********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ **********************************************************************/
+
+namespace tests\fixtures\model;
+
+use CCMBenchmark\Ting\Repository\Repository;
+
+class DepartmentRepository extends Repository
+{
+}

--- a/tests/fixtures/model/Nursery.php
+++ b/tests/fixtures/model/Nursery.php
@@ -27,17 +27,12 @@ namespace tests\fixtures\model;
 use CCMBenchmark\Ting\Entity\NotifyProperty;
 use CCMBenchmark\Ting\Entity\NotifyPropertyInterface;
 
-class City implements NotifyPropertyInterface
+class Nursery implements NotifyPropertyInterface
 {
-
     use NotifyProperty;
 
     protected $id        = null;
-    protected $name      = null;
-    protected $zipcode   = null;
-    protected $bouhId    = null;
-    protected $parks     = [];
-    protected $department = null;
+    protected $city      = null;
 
     public function setId($id)
     {
@@ -45,61 +40,18 @@ class City implements NotifyPropertyInterface
         $this->id = $id;
     }
 
-    public function setName($name)
-    {
-        $this->propertyChanged('name', $this->name, $name);
-        $this->name = $name;
-    }
-
-    public function setZipcode($zipcode)
-    {
-        $this->propertyChanged('zipcode', $this->zipcode, $zipcode);
-        $this->zipcode = (string) $zipcode;
-    }
-
-    public function setBouhId($bouhId)
-    {
-        $this->propertyChanged('bouhId', $this->bouhId, $bouhId);
-        $this->bouhId = (string) $bouhId;
-    }
-
     public function getId()
     {
         return $this->id;
     }
 
-    public function getName()
+    public function setCity(City $city)
     {
-        return $this->name;
+        $this->city = $city;
     }
 
-    public function getZipcode()
+    public function getCity()
     {
-        return $this->zipcode;
-    }
-
-    public function getBouhId()
-    {
-        return $this->bouhId;
-    }
-
-    public function parksAre(array $parks)
-    {
-        $this->parks = $parks;
-    }
-
-    public function getParks()
-    {
-        return $this->parks;
-    }
-
-    public function setDepartment(Department $department)
-    {
-        $this->department = $department;
-    }
-
-    public function getDepartment()
-    {
-        return $this->department;
+        return $this->city;
     }
 }

--- a/tests/fixtures/model/NurseryRepository.php
+++ b/tests/fixtures/model/NurseryRepository.php
@@ -1,0 +1,31 @@
+<?php
+/***********************************************************************
+ *
+ * Ting - PHP Datamapper
+ * ==========================================
+ *
+ * Copyright (C) 2014 CCM Benchmark Group. (http://www.ccmbenchmark.com)
+ *
+ ***********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ **********************************************************************/
+
+namespace tests\fixtures\model;
+
+use CCMBenchmark\Ting\Repository\Repository;
+
+class NurseryRepository extends Repository
+{
+}

--- a/tests/units/Ting/Repository/HydratorRelational.php
+++ b/tests/units/Ting/Repository/HydratorRelational.php
@@ -652,6 +652,150 @@ class HydratorRelational extends atoum
         ;
     }
 
+    public function testHydrateWithDepth3()
+    {
+        $services = new \CCMBenchmark\Ting\Services();
+        $metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory'));
+        $metadata->setConnectionName('connectionName');
+        $metadata->setDatabase('database');
+        $metadata->setEntity('tests\fixtures\model\Nursery');
+        $metadata->setTable('T_NURSERY');
+
+        $metadata->addField([
+            'primary'    => true,
+            'fieldName'  => 'id',
+            'columnName' => 'nursery_id',
+            'type'       => 'int'
+        ]);
+
+        $services->get('MetadataRepository')->addMetadata('tests\fixtures\model\NurseryRepository', $metadata);
+
+        $metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory'));
+        $metadata->setConnectionName('connectionName');
+        $metadata->setDatabase('database');
+        $metadata->setEntity('tests\fixtures\model\City');
+        $metadata->setTable('T_CITY_CIT');
+
+        $metadata->addField([
+            'primary'    => true,
+            'fieldName'  => 'id',
+            'columnName' => 'cit_id',
+            'type'       => 'int'
+        ]);
+
+        $services->get('MetadataRepository')->addMetadata('tests\fixtures\model\CityRepository', $metadata);
+
+        $metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory'));
+        $metadata->setConnectionName('connectionName');
+        $metadata->setDatabase('database');
+        $metadata->setEntity('tests\fixtures\model\Department');
+        $metadata->setTable('T_DEPARTMENT');
+
+        $metadata->addField([
+            'primary'    => true,
+            'fieldName'  => 'id',
+            'columnName' => 'department_id',
+            'type'       => 'int'
+        ]);
+
+        $services->get('MetadataRepository')->addMetadata('tests\fixtures\model\DepartmentRepository', $metadata);
+
+        $metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory'));
+        $metadata->setConnectionName('connectionName');
+        $metadata->setDatabase('database');
+        $metadata->setEntity('tests\fixtures\model\Authority');
+        $metadata->setTable('T_AUTHORITY');
+
+        $metadata->addField([
+            'primary'    => true,
+            'fieldName'  => 'id',
+            'columnName' => 'authority_id',
+            'type'       => 'int'
+        ]);
+
+        $services->get('MetadataRepository')->addMetadata('tests\fixtures\model\AuthorityRepository', $metadata);
+
+        $mockMysqliResult = new \mock\tests\fixtures\FakeDriver\MysqliResult([
+            [1, 11, 22, 33],
+        ]);
+        $this->calling($mockMysqliResult)->fetch_fields = function () {
+            $fields = [];
+
+            $stdClass = new \stdClass();
+            $stdClass->name     = 'id';
+            $stdClass->orgname  = 'nursery_id';
+            $stdClass->table    = 'o';
+            $stdClass->orgtable = 'T_NURSERY';
+            $stdClass->type     = MYSQLI_TYPE_VAR_STRING;
+            $fields[] = $stdClass;
+
+            $stdClass = new \stdClass();
+            $stdClass->name     = 'id';
+            $stdClass->orgname  = 'cit_id';
+            $stdClass->table    = 'a1';
+            $stdClass->orgtable = 'T_CITY_CIT';
+            $stdClass->type     = MYSQLI_TYPE_VAR_STRING;
+            $fields[] = $stdClass;
+
+            $stdClass = new \stdClass();
+            $stdClass->name     = 'id';
+            $stdClass->orgname  = 'department_id';
+            $stdClass->table    = 'a2';
+            $stdClass->orgtable = 'T_DEPARTMENT';
+            $stdClass->type     = MYSQLI_TYPE_VAR_STRING;
+            $fields[] = $stdClass;
+
+            $stdClass = new \stdClass();
+            $stdClass->name     = 'id';
+            $stdClass->orgname  = 'authority_id';
+            $stdClass->table    = 'a3';
+            $stdClass->orgtable = 'T_AUTHORITY';
+            $stdClass->type     = MYSQLI_TYPE_VAR_STRING;
+            $fields[] = $stdClass;
+
+            return $fields;
+        };
+
+        $result = new Result();
+        $result->setResult($mockMysqliResult);
+        $result->setConnectionName('connectionName');
+        $result->setDatabase('database');
+
+        $this
+            ->if($hydrator = new \CCMBenchmark\Ting\Repository\HydratorRelational())
+            ->and($hydrator->setMetadataRepository($services->get('MetadataRepository')))
+            ->and($hydrator->setUnitOfWork($services->get('UnitOfWork')))
+            ->and($hydrator->addRelation(new RelationOne(
+                new AggregateFrom('a1'),
+                new AggregateTo('o'),
+                'setCity'
+            )))
+            ->and($hydrator->addRelation(new RelationOne(
+                new AggregateFrom('a2'),
+                new AggregateTo('a1'),
+                'setDepartment'
+            )))
+            ->and($hydrator->addRelation(new RelationOne(
+                new AggregateFrom('a3'),
+                new AggregateTo('a2'),
+                'setAuthority'
+            )))
+            ->then($iterator = $hydrator->setResult($result)->getIterator())
+            ->then($data = $iterator->current())
+            ->integer($data['o']->getId())
+                ->isIdenticalTo(1)
+            ->object($city = $data['o']->getCity())
+            ->integer($city->getId())
+                ->isIdenticalTo(11)
+            ->object($department = $city->getDepartment())
+            ->integer($department->getId())
+                ->isIdenticalTo(22)
+            ->object($authority = $department->getAuthority())
+            ->integer($authority->getId())
+                ->isIdenticalTo(33)
+        ;
+    }
+
     public function testHydrateWithNoRelation()
     {
         $services = new \CCMBenchmark\Ting\Services();


### PR DESCRIPTION
`HydratorRelational` remove result from collection when source was fetched : https://github.com/ccmbenchmark/ting/blob/e02367d004745cdbd02ba6f5b2d575b88099d4c0/src/Ting/Repository/HydratorRelational.php#L222

This mean that hydration must be done in a specific order, depending on target and source dependence defined in `$this->config`

This fix order config to hydrate deepest dependencies first, and root entity lastly.
