### PR TITLE
feat: remove deprecated method CCMBenchmark\Ting\UnitOfWork::generateUUID()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+4.0.0 (unreleased):
+
 3.7.3 (2023-11-28):
     * Fix: HydratorRelational hydration order when many nested entities
 

--- a/NEED_TO_BE_DONE_FOR_VERSION_4.md
+++ b/NEED_TO_BE_DONE_FOR_VERSION_4.md
@@ -2,7 +2,6 @@
 - ping should be added to DriverInterface
 - getInsertIdForSequence should be added to DriverInterface
 - add a getter for tingUUID in NotifyPropertyInterface
-- UUID should be a real UUID (#34)
 - getInsertId should be named getInsertedId for consistency with getAffectedRows
 - add setTimezone to DriverInterface
 - add setDatabaseOptions to ConnectionPoolInterface

--- a/src/Ting/UnitOfWork.php
+++ b/src/Ting/UnitOfWork.php
@@ -69,17 +69,6 @@ class UnitOfWork implements PropertyListenerInterface
     }
 
     /**
-     * @return string
-     * @deprecated generateUUID() method is deprecated as of version 3.6 of Ting and will be removed in 4.0. Use generateUid() instead.
-     */
-    protected function generateUUID()
-    {
-        error_log(sprintf('%s::generateUUID() method is deprecated as of version 3.6 of Ting and will be removed in 4.0. Use %s::generateUid() instead.', self::class, self::class), E_USER_DEPRECATED);
-
-        return $this->generateUid();
-    }
-
-    /**
      * Watch changes on provided entity
      *
      * @param NotifyPropertyInterface $entity


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets | 