### PR TITLE
fix: remove remainings calls to deprecated functions in internal codebase

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+3.8.1 (2024-02-15):
+    * Remove use of deprecated code to avoid deprecation logs from internal codebase
+
 3.8.0 (2024-01-29):
     * Depreciate method DriverInterface::getInsertId() in favour of getInsertedId()
     * Depreciate method CCMBenchmark\Ting\Driver\Pgsql\Driver::getInsertIdForSequence() in favour of getInsertedIdForSequence()

--- a/src/Ting/Driver/DriverInterface.php
+++ b/src/Ting/Driver/DriverInterface.php
@@ -99,6 +99,7 @@ interface DriverInterface
     public function commit();
 
     /**
+     * @deprecated
      * @return int
      */
     public function getInsertId();

--- a/src/Ting/Driver/Mysqli/Driver.php
+++ b/src/Ting/Driver/Mysqli/Driver.php
@@ -459,6 +459,9 @@ class Driver implements DriverInterface
         return (int) $this->connection->insert_id;
     }
 
+    /**
+     * @deprecated
+     */
     public function getInsertId()
     {
         error_log(sprintf('%s::getInsertId() method is deprecated as of version 3.8 of Ting and will be removed in 4.0. Use %s::getInsertedId() instead.', self::class, self::class), E_USER_DEPRECATED);

--- a/src/Ting/Driver/Pgsql/Driver.php
+++ b/src/Ting/Driver/Pgsql/Driver.php
@@ -206,7 +206,7 @@ class Driver implements DriverInterface
      */
     public function execute($originalSQL, array $params = array(), CollectionInterface $collection = null)
     {
-        list ($sql, $paramsOrder) = $this->convertParameters($originalSQL);
+        [$sql, $paramsOrder] = $this->convertParameters($originalSQL);
 
         $values = array();
         foreach (array_keys($paramsOrder) as $key) {
@@ -270,7 +270,7 @@ class Driver implements DriverInterface
      */
     public function prepare($originalSQL)
     {
-        list ($sql, $paramsOrder) = $this->convertParameters($originalSQL);
+        [$sql, $paramsOrder] = $this->convertParameters($originalSQL);
 
         $statementName = sha1($originalSQL);
 
@@ -423,6 +423,9 @@ class Driver implements DriverInterface
         return (int) $row[0];
     }
 
+    /**
+     * @deprecated
+     */
     public function getInsertId()
     {
         error_log(sprintf('%s::getInsertId() method is deprecated as of version 3.8 of Ting and will be removed in 4.0. Use %s::getInsertedId() instead.', self::class, self::class), E_USER_DEPRECATED);
@@ -448,6 +451,9 @@ class Driver implements DriverInterface
         return (int) $row[0];
     }
 
+    /**
+     * @deprecated
+     */
     public function getInsertIdForSequence($sequenceName)
     {
         error_log(sprintf('%s::getInsertIdForSequence() method is deprecated as of version 3.8 of Ting and will be removed in 4.0. Use %s::getInsertedIdForSequence() instead.', self::class, self::class), E_USER_DEPRECATED);

--- a/src/Ting/Query/Query.php
+++ b/src/Ting/Query/Query.php
@@ -133,6 +133,7 @@ class Query implements QueryInterface
     }
 
     /**
+     * @deprecated
      * @return int
      * @throws Exception
      */

--- a/src/Ting/Query/QueryInterface.php
+++ b/src/Ting/Query/QueryInterface.php
@@ -60,6 +60,7 @@ interface QueryInterface
     public function setParams(array $params);
 
     /**
+     * @deprecated
      * @return int
      */
     public function getInsertId();

--- a/src/Ting/Repository/Metadata.php
+++ b/src/Ting/Repository/Metadata.php
@@ -362,12 +362,12 @@ class Metadata
             return false;
         }
 
-        if (method_exists($driver, 'getInsertIdForSequence') === true
+        if (method_exists($driver, 'getInsertedIdForSequence') === true
             && isset($this->autoincrement['sequenceName']) === true
         ) {
-            $insertId = $driver->getInsertIdForSequence($this->autoincrement['sequenceName']);
+            $insertId = $driver->getInsertedIdForSequence($this->autoincrement['sequenceName']);
         } else {
-            $insertId = $driver->getInsertId();
+            $insertId = $driver->getInsertedId();
         }
 
         $property = 'set' . $this->autoincrement['fieldName'];

--- a/tests/units/Ting/Repository/Metadata.php
+++ b/tests/units/Ting/Repository/Metadata.php
@@ -423,7 +423,7 @@ class Metadata extends atoum
         ));
 
         $driver = new \mock\CCMBenchmark\Ting\Driver\Mysqli\Driver();
-        $this->calling($driver)->getInsertId = 321;
+        $this->calling($driver)->getInsertedId = 321;
 
         $bouh = $metadata->createEntity();
         $this->calling($bouh)->setId = function ($id) {
@@ -449,7 +449,7 @@ class Metadata extends atoum
         ));
 
         $driver = new \mock\CCMBenchmark\Ting\Driver\Mysqli\Driver();
-        $this->calling($driver)->getInsertId = 321;
+        $this->calling($driver)->getInsertedId = 321;
 
         $bouh = $metadata->createEntity();
         $this->calling($bouh)->setId = function ($id) {

--- a/tests/units/Ting/UnitOfWork.php
+++ b/tests/units/Ting/UnitOfWork.php
@@ -313,7 +313,7 @@ class UnitOfWork extends atoum
         $this->calling($mockPreparedQuery)->execute = true;
 
         $mockDriver = new \mock\CCMBenchmark\Ting\Driver\Mysqli\Driver();
-        $this->calling($mockDriver)->getInsertId = 1;
+        $this->calling($mockDriver)->getInsertedId = 1;
         $this->calling($mockDriver)->closeStatement = true;
 
         $this->calling($mockQueryFactory)->getPrepared = $mockPreparedQuery;
@@ -359,7 +359,7 @@ class UnitOfWork extends atoum
         $this->calling($mockPreparedQuery)->execute = true;
 
         $mockDriver = new \mock\CCMBenchmark\Ting\Driver\Mysqli\Driver();
-        $this->calling($mockDriver)->getInsertId = 1;
+        $this->calling($mockDriver)->getInsertedId = 1;
         $this->calling($mockDriver)->closeStatement = true;
 
 
@@ -407,7 +407,7 @@ class UnitOfWork extends atoum
         $this->calling($mockPreparedQuery)->execute = true;
 
         $mockDriver = new \mock\CCMBenchmark\Ting\Driver\Mysqli\Driver();
-        $this->calling($mockDriver)->getInsertId = 1;
+        $this->calling($mockDriver)->getInsertedId = 1;
 
 
         $this->calling($mockQueryFactory)->getPrepared = $mockPreparedQuery;


### PR DESCRIPTION
…base

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets | 

This avoids deprecation logs generation since method deprecated methods should not be used in internal codebase.