### PR TITLE
fix: catch mysqli::ping() exception in order to try to reconnect

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+3.9.1 (2024-XX-XX):
+    * Fix: Mysqli/Driver::ping() try to reconnect when mysqli::ping() throws an exception
+
 3.9.0 (2024-02-20):
     * Add support of order and limit in method `getBy()` of repositories
 

--- a/src/Ting/Driver/Mysqli/Driver.php
+++ b/src/Ting/Driver/Mysqli/Driver.php
@@ -506,7 +506,16 @@ class Driver implements DriverInterface
             throw new NeverConnectedException('Please connect to your database before trying to ping it.');
         }
 
-        if ($this->connection->ping() === true) {
+        $pingResult = false;
+
+        try {
+            $pingResult = $this->connection->ping();
+        } catch(\Exception $errorException) {
+            // mysqli::ping() throws an exception if the connection has gone down ("MySQL server has gone away").
+            // We catch it as a ping failure (returns false) in order to try to reconnect.
+        }
+
+        if ($pingResult === true) {
             return true;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets |

Mysqli/Driver::ping() relies on mysqli::ping() which throws exceptions when connection has gone down. This is the case when connection timeout is reached ("MySQL server has gone away"). I consider this current behavior a bug because this function should try to reconnect and return false on failure.

I've tried to change the report_mode to MYSQLI_REPORT_OFF but exceptions are still thrown.

