### PR TITLE
feature: Add DateTimeImmutable serialization

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,20 +2,27 @@ name: Tests
 
 on:
   push:
+    branches:
+      - "master"
   pull_request:
-  schedule:
-    -   cron: '0 0 * * MON'
 
 jobs:
   run:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php:
+          - 8.0
+          - 8.1
+          - 8.2
+          - 8.3
+          - 8.4
+        composer:
+          - v2
     name: Run Unit Tests on PHP ${{ matrix.php }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 3.10.0 (unreleased):
     * Remove hard dependency to pimple, add it in suggest
     * Collection is now JsonSerializable
+    * Add DateTimeImmutable serialization
     * Fix: Query Generator now handle null values
 
 3.9.1 (2024-07-19):

--- a/src/Ting/Serializer/DateTimeImmutable.php
+++ b/src/Ting/Serializer/DateTimeImmutable.php
@@ -1,0 +1,91 @@
+<?php
+/***********************************************************************
+ *
+ * Ting - PHP Datamapper
+ * ==========================================
+ *
+ * Copyright (C) 2014 CCM Benchmark Group. (http://www.ccmbenchmark.com)
+ *
+ ***********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ **********************************************************************/
+
+namespace CCMBenchmark\Ting\Serializer;
+
+class DateTimeImmutable implements SerializerInterface
+{
+    /**
+     * @var array
+     * format => Always used for serialization. Used for unserialization only if unSerializeUseFormat is true
+     * unSerializeUseFormat => if false, any valid datetime format is automatically used
+     * @see http://php.net/manual/en/datetime.formats.compound.php
+     */
+    private static $defaultOptions = ['format' => \DateTimeInterface::ATOM, 'unSerializeUseFormat' => true];
+    private static $deserialisationFormat = 'Y-m-d\TH:i:sO';
+
+    /**
+     * @param \DateTime $toSerialize
+     * @param array $options
+     * @return string|null
+     * @throws RuntimeException
+     */
+    public function serialize($toSerialize, array $options = []): ?string
+    {
+        if ($toSerialize === null) {
+            return null;
+        }
+
+        if (($toSerialize instanceof \DateTimeImmutable) === false) {
+            throw new RuntimeException(
+                'Cannot convert this value to DateTimeImmutable. Type was : ' . \gettype($toSerialize) .
+                '. Instance of DateTimeImmutable expected.'
+            );
+        }
+        $options = array_merge(self::$defaultOptions, $options);
+        return $toSerialize->format($options['format']);
+    }
+
+    /**
+     * @param string $serialized
+     * @param array  $options
+     * @return \DateTimeImmutable|null
+     * @throws RuntimeException
+     */
+    public function unserialize($serialized, array $options = []): ?\DateTimeImmutable
+    {
+        if ($serialized === null) {
+            return null;
+        }
+
+        //$this->parseSerialized($serialized);
+        $options = array_merge(self::$defaultOptions, $options);
+        if ($options['unSerializeUseFormat'] === true) {
+            $value = \DateTimeImmutable::createFromFormat($options['format'], $serialized);
+            if ($value === false) {
+                throw new RuntimeException('Cannot convert ' . $serialized . ' to DateTimeImmutable.');
+            }
+        } else {
+            try {
+                $value = new \DateTimeImmutable($serialized);
+            } catch (\Exception $e) {
+                throw new RuntimeException(
+                    'Cannot convert ' . $serialized . ' to DateTimeImmutable. Error is : ' . $e->getMessage()
+                );
+            }
+        }
+
+        return $value;
+    }
+}

--- a/tests/units/Ting/Serializer/DateTimeImmutable.php
+++ b/tests/units/Ting/Serializer/DateTimeImmutable.php
@@ -1,0 +1,84 @@
+<?php
+/***********************************************************************
+ *
+ * Ting - PHP Datamapper
+ * ==========================================
+ *
+ * Copyright (C) 2014 CCM Benchmark Group. (http://www.ccmbenchmark.com)
+ *
+ ***********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ **********************************************************************/
+
+namespace tests\units\CCMBenchmark\Ting\Serializer;
+
+use atoum;
+
+class DateTimeImmutable extends atoum
+{
+
+    public function testSerializeThenUnSerializeShouldReturnOriginalValue()
+    {
+        $datetime = new \DateTimeImmutable('now');
+        $this
+            ->if($serializer = new \CCMBenchmark\Ting\Serializer\DateTimeImmutable())
+            ->string($serializer->unserialize($serializer->serialize($datetime))->format(\DateTimeInterface::ATOM))
+            ->isEqualTo($datetime->format(\DateTimeInterface::ATOM))
+        ;
+    }
+
+    public function testUnserializeInvalidValueShouldRaiseException()
+    {
+        $this
+            ->if($serializer = new \CCMBenchmark\Ting\Serializer\DateTimeImmutable())
+            ->exception(function () use ($serializer) {
+                $serializer->unserialize('1345-67-89 bouh');
+            })
+            ->isInstanceOf('CCMBenchmark\Ting\Serializer\RuntimeException')
+        ;
+    }
+
+    public function testUnserializeAutoShouldWorkWithCommonFormat()
+    {
+        $this
+            ->if($serializer = new \CCMBenchmark\Ting\Serializer\DateTimeImmutable())
+            ->object($serializer->unserialize('2009-10-20 17:43:15', ['unSerializeUseFormat' => false]))
+            ->object($serializer->unserialize('2008-08-04 12:47:54.659698', ['unSerializeUseFormat' => false]))
+            ->object($serializer->unserialize('2008-08-04 12:47', ['unSerializeUseFormat' => false]))
+            ->object($serializer->unserialize('2008-08-04', ['unSerializeUseFormat' => false]));
+    }
+
+    public function testSerializeInvalidValueShouldRaiseException()
+    {
+        $this
+            ->if($serializer = new \CCMBenchmark\Ting\Serializer\DateTimeImmutable())
+            ->exception(function () use ($serializer) {
+                $serializer->serialize(new \StdClass());
+            })
+            ->isInstanceOf('CCMBenchmark\Ting\Serializer\RuntimeException')
+        ;
+    }
+
+    public function testNullValueShouldBeReturned()
+    {
+        $this
+            ->if($serializer = new \CCMBenchmark\Ting\Serializer\DateTimeImmutable())
+            ->variable($serializer->serialize(null))
+            ->isNull()
+            ->variable($serializer->unserialize(null))
+            ->isNull()
+        ;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets | 

As suggested by @xavierleune in https://github.com/ccmbenchmark/ting/pull/82, this PR adds DateTimeImmutable serialization in v3.X instead of waiting for the release of v4.0