### PR TITLE
[Feature] Collection is now JsonSerializable

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+3.10.0 (unreleased):
+    * Collection is now JsonSerializable
+
 3.9.1 (2024-07-19):
     * Fix: Mysqli/Driver::ping() try to reconnect when mysqli::ping() throws an exception
 

--- a/src/Ting/Repository/Collection.php
+++ b/src/Ting/Repository/Collection.php
@@ -32,7 +32,7 @@ use CCMBenchmark\Ting\Driver\ResultInterface;
  *
  * @template-implements CollectionInterface<T>
  */
-class Collection implements CollectionInterface
+class Collection implements CollectionInterface, \JsonSerializable
 {
 
     /**
@@ -154,5 +154,10 @@ class Collection implements CollectionInterface
     public function count()
     {
         return $this->hydrator->count();
+    }
+
+    public function jsonSerialize(): array
+    {
+        return iterator_to_array($this->hydrator->getIterator());
     }
 }

--- a/tests/units/Ting/Repository/Collection.php
+++ b/tests/units/Ting/Repository/Collection.php
@@ -210,4 +210,33 @@ class Collection extends atoum
                 ->isTrue()
         ;
     }
+    
+    public function testCollectionShouldBeJsonSerializable()
+    {
+        $mockMysqliResult = new \mock\tests\fixtures\FakeDriver\MysqliResult([['Bob']]);
+        $this->calling($mockMysqliResult)->fetch_fields = function () {
+            $fields = [];
+            $stdClass = new \stdClass();
+            $stdClass->name     = 'prenom';
+            $stdClass->orgname  = 'firstname';
+            $stdClass->table    = 'bouh';
+            $stdClass->orgtable = 'T_BOUH_BOO';
+            $stdClass->type     = MYSQLI_TYPE_VAR_STRING;
+            $fields[] = $stdClass;
+
+            return $fields;
+        };
+
+        $result = new \mock\CCMBenchmark\Ting\Driver\Mysqli\Result();
+        $result->setConnectionName('connectionName');
+        $result->setDatabase('database');
+        $result->setResult($mockMysqliResult);
+        
+        $this
+            ->if($collection = new \CCMBenchmark\Ting\Repository\Collection())
+                ->and($collection->set($result))
+                    ->string(json_encode($collection))
+                        ->isEqualTo('[{"prenom":"Bob"}]')
+        ;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets | ¤

Collection can be serialized, offering a better DX when you want to pass your collection to a controller and send it in json.