### PR TITLE
[Fix] Query Generator now handle null values

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+3.10.0 (unreleased):
+    * Fix: Query Generator now handle null values
+
 3.9.1 (2024-07-19):
     * Fix: Mysqli/Driver::ping() try to reconnect when mysqli::ping() throws an exception
 

--- a/src/Ting/Query/Generator.php
+++ b/src/Ting/Query/Generator.php
@@ -361,7 +361,9 @@ class Generator
         $i = 0;
 
         foreach ($values as $field => $value) {
-            if (is_array($value) === true) {
+            if ($value === null) {
+                $conditions[] = $fields[$i] . ' IS NULL';
+            } elseif (is_array($value) === true) {
                 // handle array values...
                 $j = 0;
                 $condition = $fields[$i] . ' IN (';

--- a/tests/units/Ting/Query/Generator.php
+++ b/tests/units/Ting/Query/Generator.php
@@ -119,6 +119,29 @@ class Generator extends atoum
         ;
     }
 
+    public function testGetByCriteriaWithNullValueShouldReturnAQuery()
+    {
+        $services = new \CCMBenchmark\Ting\Services();
+
+        $this
+            ->if(
+                $generator = new \CCMBenchmark\Ting\Query\Generator(
+                    $this->mockConnection,
+                    $this->mockQueryFactory,
+                    '',
+                    'table',
+                    ['id', 'population']
+                )
+            )
+            ->object($generator->getByCriteria(['name' => null], $services->get('CollectionFactory')))
+                ->isInstanceOf('\CCMBenchmark\Ting\Query\Query')
+            ->mock($this->mockQueryFactory)
+                ->call('get')
+                    ->withAtLeastArguments(['SELECT `id`, `population` FROM `table` WHERE name IS NULL'])
+                        ->once()
+        ;
+    }
+
     public function testGetByCriteriaShouldReturnAQuery()
     {
         $services = new \CCMBenchmark\Ting\Services();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets | ¤

Before this pull request, the generator gave the following sql: `SELECT `id`, `population` FROM `table` WHERE name = #name` (with #name being a parameter for the prepared query, later evaluated to `null`).