### PR TITLE
[Feature] Support for public properties

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,12 @@ jobs:
           - 8.2
           - 8.3
           - 8.4
+        deps:
+          - highest
+          - lowest
         composer:
           - v2
-    name: Run Unit Tests on PHP ${{ matrix.php }}
+    name: Run Unit Tests on PHP ${{ matrix.php }}, ${{ matrix.deps }} dependencies
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -29,10 +32,12 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: bcmath, bz2, gettext, mbstring, memcached, mcrypt, mysqli, opcache, pdo_mysql, zip, pdo, intl, json, pdo_pgsql, pgsql, session, simplexml, xml
-          tools: composer:v1, pecl
+          tools: composer:v2, pecl
 
-      - name: Install vendors
-        run: composer install --prefer-source --no-interaction
+      - name: "Install ${{ matrix.dependencies }} dependencies with composer"
+        uses: "ramsey/composer-install@v2"
+        with:
+          dependency-versions: "${{ matrix.dependencies }}"
 
       - name: Run Atoum tests
         run: php vendor/bin/atoum

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
     * Add uuid support with symfony/uid
     * Refacto: use, when possible, Weakmap for UnitOfWork internal storage instead of uuid indexed array
     * Fix: Query Generator now handle null values
+    * Feature: Support for public properties with hooks (8.4+)
 
 3.9.1 (2024-07-19):
     * Fix: Mysqli/Driver::ping() try to reconnect when mysqli::ping() throws an exception

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "require": {
         "php": ">=8.0",
         "aura/sqlquery": "^2.6",
-        "doctrine/cache": "^1.6"
+        "doctrine/cache": "^1.6",
+        "symfony/property-access": "^6.0 || ^7.0"
     },
     "require-dev": {
         "ext-pgsql": "*",
@@ -32,7 +33,8 @@
         "atoum/stubs": "^2.0",
         "brick/geo": "^0.5.1",
 	    "pimple/pimple": "^3.0",
-        "symfony/uid": "^6.0 || ^7.0"
+        "symfony/uid": "^6.0 || ^7.0",
+        "symfony/cache": "^6.0 || ^7.0"
     },
     "suggest": {
       "brick/geo": "Allow support of MariaDB Geometry type",

--- a/src/Ting/MetadataRepository.php
+++ b/src/Ting/MetadataRepository.php
@@ -29,8 +29,7 @@ use CCMBenchmark\Ting\Repository\Metadata;
 use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
-
-use function get_class;
+use Psr\Cache\CacheItemPoolInterface;
 use function is_object;
 
 class MetadataRepository
@@ -61,7 +60,7 @@ class MetadataRepository
     /**
      * @param SerializerFactoryInterface $serializerFactory
      */
-    public function __construct(SerializerFactoryInterface $serializerFactory)
+    public function __construct(SerializerFactoryInterface $serializerFactory, private ?CacheItemPoolInterface $cacheItemPool = null)
     {
         $this->serializerFactory = $serializerFactory;
     }
@@ -163,6 +162,7 @@ class MetadataRepository
      */
     public function addMetadata($repositoryClass, Metadata $metadata)
     {
+        $metadata->propertyAccessor->setCacheItemPool($this->cacheItemPool);
         $this->metadataList[$repositoryClass] = $metadata;
         $metadataTable = $metadata->getTable();
         $metadataConnection = $metadata->getConnectionName();

--- a/src/Ting/Repository/Hydrator.php
+++ b/src/Ting/Repository/Hydrator.php
@@ -48,6 +48,10 @@ class Hydrator implements HydratorInterface
     protected $unserializeAliases = [];
     protected WeakMap $alreadyManaged;
     protected $references         = [];
+
+    /**
+     * @var Metadata[]
+     */
     protected $metadataList       = [];
 
     /**
@@ -404,7 +408,7 @@ class Hydrator implements HydratorInterface
             if (\is_int($table) === false) {
                 $ref = $table . '-';
                 foreach ($this->metadataList[$table]->getPrimaries() as $primary) {
-                    $ref .= $entity->{$this->metadataList[$table]->getGetter($primary['fieldName'])}() . '-';
+                    $ref .= $this->metadataList[$table]->getEntityPropertyByFieldName($entity, $primary['fieldName']) . '-';
                 }
 
                 if (isset($this->references[$ref]) === false) {

--- a/src/Ting/Repository/HydratorRelational.php
+++ b/src/Ting/Repository/HydratorRelational.php
@@ -296,7 +296,7 @@ final class HydratorRelational extends Hydrator
     {
         $id = '';
         foreach ($this->metadataList[$table]->getPrimaries() as $primary) {
-            $id .= $entity->{$this->metadataList[$table]->getGetter($primary['fieldName'])}() . '-';
+            $id .= $this->metadataList[$table]->getEntityPropertyByFieldName($entity, $primary['fieldName']) . '-';
         }
 
         if ($id === '') {

--- a/src/Ting/Services.php
+++ b/src/Ting/Services.php
@@ -25,6 +25,7 @@
 
 namespace CCMBenchmark\Ting;
 
+use CCMBenchmark\Ting\Util\PropertyAccessor;
 use Pimple\Container;
 
 class Services implements ContainerInterface
@@ -130,6 +131,13 @@ class Services implements ContainerInterface
         $this->container->offsetSet(
             'Cache',
             fn () => new Cache\Cache()
+        );
+
+        $this->container->offsetSet(
+            'PropertyAccessor',
+            function () {
+                return new PropertyAccessor();
+            }
         );
     }
 

--- a/src/Ting/Util/PropertyAccessor.php
+++ b/src/Ting/Util/PropertyAccessor.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace CCMBenchmark\Ting\Util;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\PropertyAccess\PropertyPathInterface;
+
+class PropertyAccessor
+{
+    private array $reflectionData = [];
+    private array $reflectionProperties = [];
+    private const CACHE_PREFIX_WRITE = 'write_property_';
+    private PropertyAccessorInterface $propertyAccessor;
+    private ?CacheItemPoolInterface $cacheItemPool = null;
+    
+    public function __construct() {
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+    }
+
+    public function setCacheItemPool(?CacheItemPoolInterface $cacheItemPool): void
+    {
+        $this->cacheItemPool = $cacheItemPool;
+    }
+    
+    public function setValue(object $object, PropertyPathInterface|string $propertyPath, mixed $value, ?string $setter = null): void
+    {
+        if ($setter !== null) {
+            $object->$setter($value);
+            return;
+        }
+
+        $reflectionData = $this->getReflectionData($object, $propertyPath);
+
+        if ($reflectionData['public'] && $reflectionData['supportsHook'] && $reflectionData['hasSetHook']) {
+            // SetRawValue is 8.4+ only.
+            // We use it only if there is a hook we want to bypass
+            // In any other case we let the property accessor
+            $reflectionProperty = $this->getReflectionProperty($object, $propertyPath);
+            $reflectionProperty->setRawValue($object, $value);
+            return;
+        }
+        $this->propertyAccessor->setValue($object, $propertyPath, $value);
+    }
+
+    public function getValue(object $object, PropertyPathInterface|string $propertyPath, ?string $getter = null): mixed
+    {
+        if ($getter !== null) {
+            return $object->$getter();
+        }
+        return $this->propertyAccessor->getValue($object, $propertyPath);
+    }
+
+    public function isWritable(object|array $objectOrArray, PropertyPathInterface|string $propertyPath, ?string $setter): bool
+    {
+        if ($setter !== null) {
+            return method_exists($objectOrArray, $setter);
+        }
+        return $this->propertyAccessor->isWritable($objectOrArray, $propertyPath);
+    }
+
+    public function isReadable(object|array $objectOrArray, PropertyPathInterface|string $propertyPath, ?string $getter): bool
+    {
+        if ($getter !== null) {
+            return method_exists($objectOrArray, $getter);
+        }
+        return $this->propertyAccessor->isReadable($objectOrArray, $propertyPath);
+    }
+
+    /**
+     * @param object $object
+     * @param string $propertyPath
+     * @return array{'public': bool, 'supportsHook': bool, 'hasSetHook': bool}
+     * @throws \Psr\Cache\InvalidArgumentException
+     * @throws \ReflectionException
+     */
+    private function getReflectionData(object $object, string $propertyPath): array
+    {
+        $key = \get_class($object).'..'.$propertyPath;
+        if (isset($this->reflectionData[$key])) {
+            return $this->reflectionData[$key];
+        }
+
+        if ($this->cacheItemPool) {
+            $item = $this->cacheItemPool->getItem(self::CACHE_PREFIX_WRITE.rawurlencode($key));
+            if ($item->isHit()) {
+                return $this->writePropertyCache[$key] = $item->get();
+            }
+        }
+
+        $reflection = new \ReflectionProperty($object, $propertyPath);
+        $data = [
+            'public' => $reflection->isPublic(),
+            'supportsHook' => \PHP_VERSION_ID >= 80400,
+            'hasSetHook' => \PHP_VERSION_ID >= 80400 && $reflection->getHook(\PropertyHookType::Set) !== null,
+        ];
+
+        if (isset($item)) {
+            $this->cacheItemPool->save($item->set($data));
+        }
+        
+        return $this->reflectionData[$key] = $data;
+    }
+    
+    private function getReflectionProperty(object $object, string $propertyPath): \ReflectionProperty
+    {
+        $key = \get_class($object).'..'.$propertyPath;
+        if (isset($this->reflectionProperties[$key])) {
+            return $this->reflectionProperties[$key];
+        }
+        
+        return $this->reflectionProperties[$key] = new \ReflectionProperty($object, $propertyPath);
+    }
+}

--- a/tests/fixtures/model/HookedPropertiesEntity.php
+++ b/tests/fixtures/model/HookedPropertiesEntity.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace tests\fixtures\model;
+
+class HookedPropertiesEntity
+{
+    public string $hookGetOnly = 'default' {
+        get => $this->hookGetOnly . ' (hooked on get)';
+    }
+
+    public string $hookSetOnly = 'default' {
+        set(string $value) {
+            $this->hookSetOnly = $value . ' (hooked on set)';
+        }
+    }
+
+    public string $hookBoth = 'default' {
+        get => $this->hookBoth . ' (hooked on get)';
+        set(string $value) {
+            $this->hookBoth = $value . ' (hooked on set)';
+        }
+    }
+}

--- a/tests/fixtures/model/PublicPropertiesEntity.php
+++ b/tests/fixtures/model/PublicPropertiesEntity.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace tests\fixtures\model;
+
+class PublicPropertiesEntity
+{
+    public string $propertyWithSetter;
+    
+    public string $propertyWithoutSetter;
+    
+    public string $propertyWithDefaultValue = 'default';
+    
+    private string $propertyWithGetter = 'with getter';
+    
+    public function setPropertyWithSetter(string $propertyWithSetter)
+    {
+        
+    }
+
+    public function setPropertyWithDefaultValue(string $propertyWithDefaultValue): void
+    {
+        $this->propertyWithDefaultValue = $propertyWithDefaultValue;
+    }
+
+    public function getPropertyWithGetter(): string
+    {
+        return $this->propertyWithGetter;
+    }
+}

--- a/tests/units/Ting/Repository/Metadata.php
+++ b/tests/units/Ting/Repository/Metadata.php
@@ -28,6 +28,8 @@ namespace tests\units\CCMBenchmark\Ting\Repository;
 use atoum;
 use tests\fixtures\model\Bouh;
 use tests\fixtures\model\BouhCustomGetter;
+use tests\fixtures\model\HookedPropertiesEntity;
+use tests\fixtures\model\PublicPropertiesEntity;
 
 class Metadata extends atoum
 {
@@ -247,16 +249,17 @@ class Metadata extends atoum
         $services = new \CCMBenchmark\Ting\Services();
         $this
             ->if($metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory')))
-            ->then($metadata->setEntity('mock\repository\Bouh'))
+            ->then($metadata->setEntity('mock\tests\fixtures\model\Bouh'))
             ->object($bouh = $metadata->createEntity())
-                ->isInstanceOf('\mock\repository\Bouh');
+                ->isInstanceOf('mock\tests\fixtures\model\Bouh');
     }
 
     public function testSetEntityPropertyWithDefaultSetter()
     {
         $services = new \CCMBenchmark\Ting\Services();
         $metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory'));
-        $metadata->setEntity('mock\repository\Bouh');
+
+        $metadata->setEntity('mock\tests\fixtures\model\Bouh');
         $metadata->addField([
             'fieldName'  => 'name',
             'columnName' => 'boo_name',
@@ -264,112 +267,109 @@ class Metadata extends atoum
         ]);
 
         $bouh = $metadata->createEntity();
-        $this->calling($bouh)->setName = function ($name): void {
-            $this->name = $name;
-        };
 
         $this
             ->if($metadata->setEntityProperty($bouh, 'boo_name', 'Sylvain'))
-            ->string($bouh->name)
-                ->isIdenticalTo('Sylvain')
             ->mock($bouh)
                 ->call('setName')
-                    ->once();
+                    ->withArguments('Sylvain')
+                        ->once();
     }
 
     public function testSetEntityPropertyShouldKeepNull()
     {
         $services = new \CCMBenchmark\Ting\Services();
         $metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory'));
-        $metadata->setEntity('mock\repository\Bouh');
+
+        $metadata->setEntity('mock\tests\fixtures\model\Bouh');
         $metadata->addField([
-            'fieldName'  => 'old',
-            'columnName' => 'boo_old',
+            'fieldName'  => 'price',
+            'columnName' => 'boo_price',
             'type'       => 'int'
         ]);
 
         $bouh = $metadata->createEntity();
-        $this->calling($bouh)->setOld = function ($old): void {
-            $this->old = $old;
-        };
 
         $this
-            ->if($metadata->setEntityProperty($bouh, 'boo_old', null))
-            ->variable($bouh->old)
-                ->isIdenticalTo(null);
+            ->if($metadata->setEntityProperty($bouh, 'boo_price', null))
+            ->mock($bouh)
+                ->call('setPrice')
+                    ->withArguments(null)
+                        ->once()
+        ;
     }
 
     public function testSetEntityPropertyShouldCastToInt()
     {
         $services = new \CCMBenchmark\Ting\Services();
         $metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory'));
-        $metadata->setEntity('mock\repository\Bouh');
+        $metadata->setEntity('mock\tests\fixtures\model\Bouh');
         $metadata->addField([
-            'fieldName'  => 'old',
-            'columnName' => 'boo_old',
+            'fieldName'  => 'price',
+            'columnName' => 'boo_price',
             'type'       => 'int'
         ]);
 
         $bouh = $metadata->createEntity();
-        $this->calling($bouh)->setOld = function ($old): void {
-            $this->old = $old;
-        };
 
         $this
-            ->if($metadata->setEntityProperty($bouh, 'boo_old', '32'))
-            ->integer($bouh->old)
-                ->isIdenticalTo(32);
+            ->if($metadata->setEntityProperty($bouh, 'boo_price', '32'))
+            ->mock($bouh)
+                ->call('setPrice')
+                    ->withArguments(32)
+                        ->once()
+        ;
     }
 
     public function testSetEntityPropertyShouldCastToDouble()
     {
         $services = new \CCMBenchmark\Ting\Services();
         $metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory'));
-        $metadata->setEntity('mock\repository\Bouh');
+        $metadata->setEntity('mock\tests\fixtures\model\Bouh');
         $metadata->addField([
-            'fieldName'  => 'old',
-            'columnName' => 'boo_old',
+            'fieldName'  => 'price',
+            'columnName' => 'boo_price',
             'type'       => 'double'
         ]);
 
         $bouh = $metadata->createEntity();
-        $this->calling($bouh)->setOld = function ($old): void {
-            $this->old = $old;
-        };
 
         $this
-            ->if($metadata->setEntityProperty($bouh, 'boo_old', '32.3'))
-            ->float($bouh->old)
-                ->isIdenticalTo(32.3);
+            ->if($metadata->setEntityProperty($bouh, 'boo_price', '32.3'))
+            ->mock($bouh)
+                ->call('setPrice')
+                    ->withArguments(32.3)
+                        ->once()
+        ;
     }
 
     public function testSetEntityPropertyShouldCastToBool()
     {
         $services = new \CCMBenchmark\Ting\Services();
         $metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory'));
-        $metadata->setEntity('mock\repository\Bouh');
+        $metadata->setEntity('mock\tests\fixtures\model\Bouh');
         $metadata->addField([
-            'fieldName'  => 'swag',
-            'columnName' => 'boo_swag',
+            'fieldName'  => 'enabled',
+            'columnName' => 'boo_enabled',
             'type'       => 'bool'
         ]);
 
         $bouh = $metadata->createEntity();
-        $this->calling($bouh)->setSwag = function ($isSwag): void {
-            $this->swag = $isSwag;
-        };
 
         $this
-            ->if($metadata->setEntityProperty($bouh, 'boo_swag', '1'))
-            ->variable($bouh->swag)
-                ->isIdenticalTo(true);
+            ->if($metadata->setEntityProperty($bouh, 'boo_enabled', '1'))
+                ->mock($bouh)
+                    ->call('setEnabled')
+                        ->withArguments(true)
+                            ->once()
+        ;
     }
 
     public function testSetEntityPropertyShouldUnserializeData()
     {
         $services = new \CCMBenchmark\Ting\Services();
         $metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory'));
-        $metadata->setEntity('mock\repository\Bouh');
+        $metadata->setEntity('mock\tests\fixtures\model\Bouh');
         $metadata->addField([
             'fieldName'  => 'roles',
             'columnName' => 'boo_roles',
@@ -378,21 +378,20 @@ class Metadata extends atoum
         ]);
 
         $bouh = $metadata->createEntity();
-        $this->calling($bouh)->setRoles = function ($roles): void {
-            $this->roles = $roles;
-        };
 
         $this
             ->if($metadata->setEntityProperty($bouh, 'boo_roles', json_encode(['Bouh', 'Sylvain'])))
-            ->array($bouh->roles)
-                ->isIdenticalTo(['Bouh', 'Sylvain']);
+            ->mock($bouh)
+                ->call('setRoles')
+                    ->withArguments(['Bouh', 'Sylvain'])
+                        ->once();
     }
 
     public function testSetEntityPropertyShouldUnserializeDataWithOptions()
     {
         $services = new \CCMBenchmark\Ting\Services();
         $metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory'));
-        $metadata->setEntity('mock\repository\Bouh');
+        $metadata->setEntity('mock\tests\fixtures\model\Bouh');
         $metadata->addField([
             'fieldName'  => 'roles',
             'columnName' => 'boo_roles',
@@ -404,21 +403,20 @@ class Metadata extends atoum
         ]);
 
         $bouh = $metadata->createEntity();
-        $this->calling($bouh)->setRoles = function ($roles): void {
-            $this->roles = $roles;
-        };
 
         $this
             ->if($metadata->setEntityProperty($bouh, 'boo_roles', json_encode(['Bouh', 'Sylvain'])))
-            ->array($bouh->roles)
-            ->isIdenticalTo(['Bouh', 'Sylvain']);
+                ->mock($bouh)
+                    ->call('setRoles')
+                        ->withArguments(['Bouh', 'Sylvain'])
+                            ->once();
     }
 
     public function testSetEntityPropertyForAutoIncrement()
     {
         $services = new \CCMBenchmark\Ting\Services();
         $metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory'));
-        $metadata->setEntity('mock\repository\Bouh');
+        $metadata->setEntity('mock\tests\fixtures\model\Bouh');
         $metadata->addField([
             'primary'       => true,
             'autoincrement' => true,
@@ -431,21 +429,21 @@ class Metadata extends atoum
         $this->calling($driver)->getInsertedId = 321;
 
         $bouh = $metadata->createEntity();
-        $this->calling($bouh)->setId = function ($id): void {
-            $this->id = $id;
-        };
 
         $this
             ->if($metadata->setEntityPropertyForAutoIncrement($bouh, $driver))
-            ->integer($bouh->id)
-                ->isIdenticalTo(321);
+            ->mock($bouh)
+                ->call('setId')
+                    ->withArguments(321)
+                        ->once();
+        ;
     }
 
     public function testSetEntityPropertyForAutoIncrementWithoutAutoIncrementColumnShouldReturnFalse()
     {
         $services = new \CCMBenchmark\Ting\Services();
         $metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory'));
-        $metadata->setEntity('mock\repository\Bouh');
+        $metadata->setEntity('mock\tests\fixtures\model\Bouh');
         $metadata->addField([
             'primary'    => true,
             'fieldName'  => 'id',
@@ -457,9 +455,6 @@ class Metadata extends atoum
         $this->calling($driver)->getInsertedId = 321;
 
         $bouh = $metadata->createEntity();
-        $this->calling($bouh)->setId = function ($id): void {
-            $this->id = $id;
-        };
 
         $this
             ->boolean($metadata->setEntityPropertyForAutoIncrement($bouh, $driver))
@@ -475,7 +470,7 @@ class Metadata extends atoum
         $services = new \CCMBenchmark\Ting\Services();
         $this
             ->if($metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory')))
-            ->and($metadata->setEntity('mock\repository\Bouh'))
+            ->and($metadata->setEntity('mock\tests\fixtures\model\Bouh'))
             ->and(
                 $metadata->addField([
                     'primary'    => true,
@@ -555,7 +550,7 @@ class Metadata extends atoum
         $services = new \CCMBenchmark\Ting\Services();
         $this
             ->if($metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory')))
-            ->and($metadata->setEntity('mock\repository\Bouh'))
+            ->and($metadata->setEntity('mock\tests\fixtures\model\Bouh'))
             ->and(
                 $metadata->addField([
                     'primary'    => true,
@@ -591,7 +586,7 @@ class Metadata extends atoum
         $services = new \CCMBenchmark\Ting\Services();
         $this
             ->if($metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory')))
-            ->and($metadata->setEntity('mock\repository\Bouh'))
+            ->and($metadata->setEntity('mock\tests\fixtures\model\Bouh'))
             ->and(
                 $metadata->addField([
                     'primary'    => true,
@@ -629,7 +624,7 @@ class Metadata extends atoum
         $services = new \CCMBenchmark\Ting\Services();
         $this
             ->if($metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory')))
-            ->and($metadata->setEntity('mock\repository\Bouh'))
+            ->and($metadata->setEntity('mock\tests\fixtures\model\Bouh'))
             ->and(
                 $metadata->addField([
                     'primary'    => true,
@@ -658,7 +653,7 @@ class Metadata extends atoum
         $services = new \CCMBenchmark\Ting\Services();
         $this
             ->if($metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory')))
-            ->and($metadata->setEntity('mock\repository\Bouh'))
+            ->and($metadata->setEntity('mock\tests\fixtures\model\Bouh'))
             ->and(
                 $metadata->addField([
                     'primary'    => true,
@@ -702,7 +697,7 @@ class Metadata extends atoum
         $services = new \CCMBenchmark\Ting\Services();
         $this
             ->if($metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory')))
-            ->and($metadata->setEntity('mock\repository\Bouh'))
+            ->and($metadata->setEntity('mock\tests\fixtures\model\Bouh'))
             ->and($metadata->setTable('bouh'))
             ->and(
                 $metadata->addField([
@@ -777,6 +772,69 @@ class Metadata extends atoum
             ->and($query = $metadata->generateQueryForInsert($mockConnection, $mockQueryFactory, $entity))
             ->string($outerParams['boo_roles'])
                 ->isIdenticalTo(json_encode(['USER', 'ADMIN']));
+    }
+
+    public function testGenerateQueryForInsertShouldSkipUnitializedFields()
+    {
+        $services = new \CCMBenchmark\Ting\Services();
+
+        $mockDriver = new \mock\CCMBenchmark\Ting\Driver\Mysqli\Driver();
+        $this->calling($mockDriver)->escapeField = function ($field) {
+            return $field;
+        };
+
+        $mockConnectionPool = new \mock\CCMBenchmark\Ting\ConnectionPool();
+        $this->calling($mockConnectionPool)->master = $mockDriver;
+
+        $mockConnection = new \mock\CCMBenchmark\Ting\Connection($mockConnectionPool, 'main', 'db');
+
+        $mockPreparedQuery = new \mock\CCMBenchmark\Ting\Query\PreparedQuery(
+            '',
+            $mockConnection,
+            $services->get('CollectionFactory')
+        );
+        $this->calling($mockPreparedQuery)->setParams = function ($params) use (&$outerParams) {
+            $outerParams = $params;
+        };
+
+        $mockQueryFactory = new \mock\CCMBenchmark\Ting\Query\QueryFactory();
+        $this->calling($mockQueryFactory)->getPrepared = $mockPreparedQuery;
+
+        $entity = new PublicPropertiesEntity();
+
+        $this
+            ->if($metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory')))
+            ->and($metadata->setEntity('mock\tests\fixtures\PublicPropertiesEntity'))
+            ->and(
+                $metadata
+                    ->addField([
+                        'primary'    => false,
+                        'fieldName'  => 'propertyWithSetter',
+                        'columnName' => 'property_with_setter',
+                        'type'       => 'string',
+                    ])
+                    ->addField([
+                        'primary'    => false,
+                        'fieldName'  => 'propertyWithoutSetter',
+                        'columnName' => 'property_without_setter',
+                        'type'       => 'string',
+                    ])
+                    ->addField([
+                        'primary'    => false,
+                        'fieldName'  => 'propertyWithDefaultValue',
+                        'columnName' => 'property_with_default_value',
+                        'type'       => 'string',
+                    ])
+                    ->addField([
+                        'primary'    => false,
+                        'fieldName'  => 'propertyWithGetter',
+                        'columnName' => 'property_with_getter',
+                        'type'       => 'string',
+                    ])
+            )
+            ->and($query = $metadata->generateQueryForInsert($mockConnection, $mockQueryFactory, $entity))
+            ->array($outerParams)
+                ->isIdenticalTo(['property_with_default_value' => 'default', 'property_with_getter' => 'with getter']);
     }
 
     public function testGenerateQueryForInsertShouldSerializeWithOptions()
@@ -858,7 +916,7 @@ class Metadata extends atoum
 
         $this
             ->if($metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory')))
-            ->and($metadata->setEntity('mock\repository\Bouh'))
+            ->and($metadata->setEntity('mock\tests\fixtures\model\Bouh'))
             ->and(
                 $metadata->addField([
                     'primary'       => true,
@@ -1037,7 +1095,7 @@ class Metadata extends atoum
 
         $this
             ->if($metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory')))
-                ->and($metadata->setEntity('mock\repository\BouhCustomGetter'))
+                ->and($metadata->setEntity('mock\tests\fixtures\model\BouhCustomGetter'))
                 ->and(
                     $metadata->addField([
                         'primary'    => true,
@@ -1093,4 +1151,49 @@ class Metadata extends atoum
                 ->isIdenticalTo($setter);
     }
 
+    /**
+     * @php >= 8.4
+     */
+    public function testSetEntityPropertyShouldByPassPropertyHook()
+    {
+        $services = new \CCMBenchmark\Ting\Services();
+        $metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory'));
+        $metadata->setEntity(HookedPropertiesEntity::class);
+        $metadata
+            ->addField(array(
+                'fieldName'  => 'hookSetOnly',
+                'columnName' => 'hook_set_only',
+                'type'       => 'string',
+            ))
+        ;
+        $entity = new HookedPropertiesEntity();
+        $metadata->setEntityProperty($entity, 'hook_set_only', 'value');
+        $this
+            ->string($entity->hookSetOnly)
+                ->isIdenticalTo('value')
+        ;
+    }
+    
+    /**
+     * @php >= 8.4
+     */
+    public function testGetEntityPropertyShouldUsePropertyHook()
+    {
+        $services = new \CCMBenchmark\Ting\Services();
+        $metadata = new \CCMBenchmark\Ting\Repository\Metadata($services->get('SerializerFactory'));
+        $metadata->setEntity(HookedPropertiesEntity::class);
+        $metadata
+            ->addField(array(
+                'fieldName'  => 'hookBoth',
+                'columnName' => 'hook_both',
+                'type'       => 'string',
+            ))
+        ;
+        $entity = new HookedPropertiesEntity();
+        $metadata->setEntityProperty($entity, 'hook_both', 'value');
+        $this
+            ->string($metadata->getEntityPropertyByFieldName($entity, 'hookBoth'))
+                ->isIdenticalTo('value (hooked on get)')
+        ;
+    }
 }

--- a/tests/units/Ting/Util/PropertyAccessor.php
+++ b/tests/units/Ting/Util/PropertyAccessor.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace tests\units\CCMBenchmark\Ting\Util;
+
+use atoum;
+use tests\fixtures\model\HookedPropertiesEntity;
+use tests\fixtures\model\PublicPropertiesEntity;
+
+class PropertyAccessor extends \atoum
+{
+    /**
+     * @php >= 8.4
+     */
+    public function testSetPropertyShouldBypassPropertyHook()
+    {
+        $accessor = new \CCMBenchmark\Ting\Util\PropertyAccessor();
+        $entity = new HookedPropertiesEntity();
+        $this
+            ->if($accessor->setValue($entity, 'hookBoth', 'value', null))
+                ->string($entity->hookBoth)
+                    ->isIdenticalTo('value (hooked on get)')
+        ;
+    }
+    
+    public function testSetPropertyShouldRespectSetter()
+    {
+
+        $accessor = new \CCMBenchmark\Ting\Util\PropertyAccessor();
+        $entity = new \mock\tests\fixtures\model\PublicPropertiesEntity();
+        $this
+            ->if($accessor->setValue($entity, 'propertyWithSetter', 'value', 'setPropertyWithSetter'))
+            ->mock($entity)
+                ->call('setPropertyWithSetter')
+                    ->withArguments('value')
+                        ->once()
+        ;
+    }
+    
+    public function testSetPropertyShouldFindSetter()
+    {
+        $accessor = new \CCMBenchmark\Ting\Util\PropertyAccessor();
+        $entity = new \mock\tests\fixtures\model\PublicPropertiesEntity();
+        $this
+            ->if($accessor->setValue($entity, 'propertyWithSetter', 'value', null))
+            ->mock($entity)
+                ->call('setPropertyWithSetter')
+                    ->withArguments('value')
+                        ->once()
+        ;
+    }
+    
+    public function testGetPropertyShouldRespectGetter()
+    {
+        $accessor = new \CCMBenchmark\Ting\Util\PropertyAccessor();
+        $entity = new \mock\tests\fixtures\model\PublicPropertiesEntity();
+        $this
+            ->if($accessor->getValue($entity, 'propertyWithGetter', 'getPropertyWithGetter'))
+            ->mock($entity)
+                ->call('getPropertyWithGetter')
+                    ->withoutAnyArgument()
+                        ->once()
+        ;
+    }
+    
+    public function testGetPropertyShouldFindGetter()
+    {
+        $accessor = new \CCMBenchmark\Ting\Util\PropertyAccessor();
+        $entity = new \mock\tests\fixtures\model\PublicPropertiesEntity();
+        $this
+            ->if($accessor->getValue($entity, 'propertyWithGetter', null))
+            ->mock($entity)
+                ->call('getPropertyWithGetter')
+                    ->withoutAnyArgument()
+                        ->once()
+        ;
+    }
+    
+    public function testGetPropertyShouldThrowOnUnitializedProperty()
+    {
+        
+        $accessor = new \CCMBenchmark\Ting\Util\PropertyAccessor();
+        $entity = new \mock\tests\fixtures\model\PublicPropertiesEntity();
+        $this
+            ->exception(function () use ($accessor, $entity) {
+                $accessor->getValue($entity, 'propertyWithSetter', null);
+            })
+                ->isInstanceOf(\Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException::class)
+        ;
+    }
+    
+    public function testIsReadableShouldReturnTrueOnInitializedProperty()
+    {
+        $accessor = new \CCMBenchmark\Ting\Util\PropertyAccessor();
+        $entity = new \mock\tests\fixtures\model\PublicPropertiesEntity();
+        $this
+            ->boolean($accessor->isReadable($entity, 'propertyWithDefaultValue', null))
+                ->isTrue()
+        ;
+    }
+    
+    public function testIsReadableShouldReturnFalseOnUnitializedProperty()
+    {
+        $accessor = new \CCMBenchmark\Ting\Util\PropertyAccessor();
+        $entity = new \mock\tests\fixtures\model\PublicPropertiesEntity();
+        $this
+            ->boolean($accessor->isReadable($entity, 'propertyWithoutSetter', null))
+                ->isFalse()
+        ;
+    }
+    
+    public function testIsReadableShouldReturnTrueWhenAGetterIsDefined()
+    {
+        $accessor = new \CCMBenchmark\Ting\Util\PropertyAccessor();
+        $entity = new \mock\tests\fixtures\model\PublicPropertiesEntity();
+        $this
+            ->boolean($accessor->isReadable($entity, 'propertyWithGetter', 'getPropertyWithGetter'))
+                ->isTrue()
+        ;
+    }
+    
+    public function testIsReadableShouldReturnFalseWhenGetterDoesNotExists()
+    {
+        $accessor = new \CCMBenchmark\Ting\Util\PropertyAccessor();
+        $entity = new \mock\tests\fixtures\model\PublicPropertiesEntity();
+        $this
+            ->boolean($accessor->isReadable($entity, 'propertyWithGetter', 'wrongGetterName'))
+                ->isFalse()
+        ;
+    }
+    
+    public function testIsWritableShouldReturnTrueWhenASetterIsDefined()
+    {
+        $accessor = new \CCMBenchmark\Ting\Util\PropertyAccessor();
+        $entity = new \mock\tests\fixtures\model\PublicPropertiesEntity();
+        $this
+            ->boolean($accessor->isWritable($entity, 'propertyWithSetter', 'setPropertyWithDefaultValue'))
+                ->isTrue()
+        ;
+    }
+    
+    public function testIsWritableShouldReturnFalseWhenSetterDoesNotExists()
+    {
+        $accessor = new \CCMBenchmark\Ting\Util\PropertyAccessor();
+        $entity = new \mock\tests\fixtures\model\PublicPropertiesEntity();
+        $this
+            ->boolean($accessor->isWritable($entity, 'propertyWithSetter', 'wrongSetterName'))
+                ->isFalse()
+        ;
+    }
+    
+    public function testPropertyAccessorCanLeverageInternalCache()
+    {
+        $cache = new \mock\Symfony\Component\Cache\Adapter\ArrayAdapter();
+        $accessor = new \CCMBenchmark\Ting\Util\PropertyAccessor();
+        $accessor->setCacheItemPool($cache);
+        $entity = new PublicPropertiesEntity();
+        $this
+            ->if($accessor->setValue($entity, 'propertyWithDefaultValue', 'value1', null))
+            ->and($accessor->setValue($entity, 'propertyWithDefaultValue', 'value2', null))
+            ->mock($cache)
+                ->call('getItem')
+                    ->withAnyArguments()
+                        ->once()
+        ;
+    }
+    
+    public function testPropertyAccessorCanLeverageExternalCache()
+    {
+        $cache = new \mock\Symfony\Component\Cache\Adapter\ArrayAdapter();
+        $accessorFirst = new \CCMBenchmark\Ting\Util\PropertyAccessor();
+        $accessorFirst->setCacheItemPool($cache);
+        $accessorSecond = new \CCMBenchmark\Ting\Util\PropertyAccessor();
+        $accessorSecond->setCacheItemPool($cache);
+        $entity = new PublicPropertiesEntity();
+        $this
+            ->if($accessorFirst->setValue($entity, 'propertyWithDefaultValue', 'value1', null))
+            ->and($accessorSecond->setValue($entity, 'propertyWithDefaultValue', 'value2', null))
+            ->mock($cache)
+                ->call('getItem')
+                    ->withAnyArguments()
+                        ->twice()
+        ;
+    }
+}


### PR DESCRIPTION
This pull requests add supports for entities with public properties.


| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes: `Metadata::getGetter` and `Metadata::getSetter`
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets | ¤

Todo:
- [x] Cover new cases with tests
- [x] Check if value is readable before reading it (public non nullable typed properties), when trying to save a partially hydrated entity or a partially created entity ; relying on default values
- [x] Mark deprecations for `getGetter` and `getSetter`
- [x] Dependency injection for `PropertyAccessor`, to have a `CacheItemPoolInterface`, if available
- [x] `TingBundle` relies on `getGetter` in Constraints, remove this dependency
- [x] Test on SF 6

Properties can have a property hook to notify the UnitOfWork.