### PR TITLE
Fix for PHP8.4: Implicitly marking parameter %s as nullable is deprecated

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+3.10.1 (unreleased):
+    * Fix for PHP8.4: "Implicitly marking parameter %s as nullable is deprecated"
+
 3.10.0 (2025-01-06):
     * Drop PHP 7
     * Remove hard dependency to pimple, add it in suggest

--- a/src/Ting/ConnectionPool.php
+++ b/src/Ting/ConnectionPool.php
@@ -59,7 +59,7 @@ class ConnectionPool implements ConnectionPoolInterface
     /**
      * @param DriverLoggerInterface $logger
      */
-    public function __construct(DriverLoggerInterface $logger = null)
+    public function __construct(?DriverLoggerInterface $logger = null)
     {
         $this->logger = $logger;
     }

--- a/src/Ting/Driver/DriverInterface.php
+++ b/src/Ting/Driver/DriverInterface.php
@@ -64,7 +64,7 @@ interface DriverInterface
      * @return mixed
      * @throws QueryException
      */
-    public function execute($sql, array $params = [], CollectionInterface $collection = null);
+    public function execute($sql, array $params = [], ?CollectionInterface $collection = null);
 
     /**
      * @param string $sql
@@ -114,7 +114,7 @@ interface DriverInterface
      */
     public function getAffectedRows();
 
-    public function setLogger(DriverLoggerInterface $logger = null);
+    public function setLogger(?DriverLoggerInterface $logger = null);
 
     /**
      * @param array $connectionConfig

--- a/src/Ting/Driver/Mysqli/Driver.php
+++ b/src/Ting/Driver/Mysqli/Driver.php
@@ -210,7 +210,7 @@ class Driver implements DriverInterface
     /**
      * @param DriverLoggerInterface $logger
      */
-    public function setLogger(DriverLoggerInterface $logger = null)
+    public function setLogger(?DriverLoggerInterface $logger = null)
     {
         $this->logger = $logger;
         $this->objectHash = spl_object_hash($this);
@@ -269,7 +269,7 @@ class Driver implements DriverInterface
      * @return mixed|CollectionInterface
      * @throws QueryException
      */
-    public function execute($sql, array $params = [], CollectionInterface $collection = null)
+    public function execute($sql, array $params = [], ?CollectionInterface $collection = null)
     {
         $sql = preg_replace_callback(
             '/' . $this->parameterMatching . '/',

--- a/src/Ting/Driver/Mysqli/Statement.php
+++ b/src/Ting/Driver/Mysqli/Statement.php
@@ -71,7 +71,7 @@ class Statement implements StatementInterface
      * @return bool|CollectionInterface
      * @throws QueryException
      */
-    public function execute(array $params, CollectionInterface $collection = null)
+    public function execute(array $params, ?CollectionInterface $collection = null)
     {
         $types = '';
         $values = [];
@@ -114,7 +114,7 @@ class Statement implements StatementInterface
      * @param DriverLoggerInterface $logger
      * @return void
      */
-    public function setLogger(DriverLoggerInterface $logger = null)
+    public function setLogger(?DriverLoggerInterface $logger = null)
     {
         if ($logger !== null) {
             $this->logger = $logger;

--- a/src/Ting/Driver/Pgsql/Driver.php
+++ b/src/Ting/Driver/Pgsql/Driver.php
@@ -189,7 +189,7 @@ class Driver implements DriverInterface
         return $this;
     }
 
-    public function setLogger(DriverLoggerInterface $logger = null)
+    public function setLogger(?DriverLoggerInterface $logger = null)
     {
         $this->logger = $logger;
         $this->objectHash = spl_object_hash($this);
@@ -204,7 +204,7 @@ class Driver implements DriverInterface
      * @return CollectionInterface|mixed|resource
      * @throws QueryException
      */
-    public function execute($originalSQL, array $params = [], CollectionInterface $collection = null)
+    public function execute($originalSQL, array $params = [], ?CollectionInterface $collection = null)
     {
         [$sql, $paramsOrder] = $this->convertParameters($originalSQL);
 

--- a/src/Ting/Driver/Pgsql/Statement.php
+++ b/src/Ting/Driver/Pgsql/Statement.php
@@ -85,7 +85,7 @@ class Statement implements StatementInterface
      * @param DriverLoggerInterface $logger
      * @return void
      */
-    public function setLogger(DriverLoggerInterface $logger = null)
+    public function setLogger(?DriverLoggerInterface $logger = null)
     {
         $this->logger = $logger;
     }
@@ -98,7 +98,7 @@ class Statement implements StatementInterface
      * @return bool|mixed
      * @throws QueryException
      */
-    public function execute(array $params, CollectionInterface $collection = null)
+    public function execute(array $params, ?CollectionInterface $collection = null)
     {
         $values = [];
         foreach (array_keys($this->paramsOrder) as $key) {
@@ -132,7 +132,7 @@ class Statement implements StatementInterface
      *
      * @internal
      */
-    public function setCollectionWithResult($resultResource, CollectionInterface $collection = null)
+    public function setCollectionWithResult($resultResource, ?CollectionInterface $collection = null)
     {
         $result = new Result();
         $result->setConnectionName($this->connectionName);

--- a/src/Ting/Driver/StatementInterface.php
+++ b/src/Ting/Driver/StatementInterface.php
@@ -44,11 +44,11 @@ interface StatementInterface
      * @return mixed
      * @throws QueryException
      */
-    public function execute(array $params, CollectionInterface $collection = null);
+    public function execute(array $params, ?CollectionInterface $collection = null);
 
     /**
      * @param DriverLoggerInterface $logger
      * @return void
      */
-    public function setLogger(DriverLoggerInterface $logger = null);
+    public function setLogger(?DriverLoggerInterface $logger = null);
 }

--- a/src/Ting/MetadataRepository.php
+++ b/src/Ting/MetadataRepository.php
@@ -81,7 +81,7 @@ class MetadataRepository
         $schema,
         $table,
         \Closure $callbackFound,
-        \Closure $callbackNotFound = null
+        ?\Closure $callbackNotFound = null
     ) {
 
         $connectionKey = $connectionName . '#' . $table;
@@ -116,7 +116,7 @@ class MetadataRepository
     public function findMetadataForRepository(
         $repositoryName,
         \Closure $callbackFound,
-        \Closure $callbackNotFound = null
+        ?\Closure $callbackNotFound = null
     ) {
         if (isset($this->metadataList[$repositoryName]) === true) {
             $callbackFound($this->metadataList[$repositoryName]);
@@ -134,7 +134,7 @@ class MetadataRepository
      *
      * @internal
      */
-    public function findMetadataForEntity($entity, \Closure $callbackFound, \Closure $callbackNotFound = null)
+    public function findMetadataForEntity($entity, \Closure $callbackFound, ?\Closure $callbackNotFound = null)
     {
         if (is_object($entity)) {
             $entity = $entity::class;

--- a/src/Ting/Query/Cached/PreparedQuery.php
+++ b/src/Ting/Query/Cached/PreparedQuery.php
@@ -82,7 +82,7 @@ class PreparedQuery extends Query
      * @return CollectionInterface
      * @throws QueryException
      */
-    public function query(CollectionInterface $collection = null)
+    public function query(?CollectionInterface $collection = null)
     {
         $this->checkTtl();
 

--- a/src/Ting/Query/Cached/Query.php
+++ b/src/Ting/Query/Cached/Query.php
@@ -120,7 +120,7 @@ class Query extends \CCMBenchmark\Ting\Query\Query
      * @throws Exception
      * @throws QueryException
      */
-    public function query(CollectionInterface $collection = null)
+    public function query(?CollectionInterface $collection = null)
     {
         $this->checkTtl();
 

--- a/src/Ting/Query/PreparedQuery.php
+++ b/src/Ting/Query/PreparedQuery.php
@@ -86,7 +86,7 @@ class PreparedQuery extends Query
      * @return CollectionInterface
      * @throws QueryException
      */
-    public function query(CollectionInterface $collection = null)
+    public function query(?CollectionInterface $collection = null)
     {
         if ($collection === null) {
             $collection = $this->collectionFactory->get();

--- a/src/Ting/Query/Query.php
+++ b/src/Ting/Query/Query.php
@@ -57,7 +57,7 @@ class Query implements QueryInterface
      * @param Connection $connection
      * @param CollectionFactoryInterface $collectionFactory
      */
-    public function __construct(protected $sql, Connection $connection, CollectionFactoryInterface $collectionFactory = null)
+    public function __construct(protected $sql, Connection $connection, ?CollectionFactoryInterface $collectionFactory = null)
     {
         $this->connection        = $connection;
         $this->collectionFactory = $collectionFactory;
@@ -92,7 +92,7 @@ class Query implements QueryInterface
      * @throws Exception
      * @throws QueryException
      */
-    public function query(CollectionInterface $collection = null)
+    public function query(?CollectionInterface $collection = null)
     {
         if ($collection === null) {
             $collection = $this->collectionFactory->get();

--- a/src/Ting/Query/QueryFactory.php
+++ b/src/Ting/Query/QueryFactory.php
@@ -37,7 +37,7 @@ class QueryFactory implements QueryFactoryInterface
      * @param CollectionFactoryInterface $collectionFactory
      * @return Query
      */
-    public function get($sql, Connection $connection, CollectionFactoryInterface $collectionFactory = null)
+    public function get($sql, Connection $connection, ?CollectionFactoryInterface $collectionFactory = null)
     {
         return new Query($sql, $connection, $collectionFactory);
     }
@@ -48,7 +48,7 @@ class QueryFactory implements QueryFactoryInterface
      * @param CollectionFactoryInterface $collectionFactory
      * @return PreparedQuery
      */
-    public function getPrepared($sql, Connection $connection, CollectionFactoryInterface $collectionFactory = null)
+    public function getPrepared($sql, Connection $connection, ?CollectionFactoryInterface $collectionFactory = null)
     {
         return new PreparedQuery($sql, $connection, $collectionFactory);
     }
@@ -64,7 +64,7 @@ class QueryFactory implements QueryFactoryInterface
         $sql,
         Connection $connection,
         Cache $cache,
-        CollectionFactoryInterface $collectionFactory = null
+        ?CollectionFactoryInterface $collectionFactory = null
     ) {
         $cachedQuery = new Cached\Query($sql, $connection, $collectionFactory);
         $cachedQuery->setCache($cache);
@@ -82,7 +82,7 @@ class QueryFactory implements QueryFactoryInterface
         $sql,
         Connection $connection,
         Cache $cache,
-        CollectionFactoryInterface $collectionFactory = null
+        ?CollectionFactoryInterface $collectionFactory = null
     ) {
         $cachedPreparedQuery = new Cached\PreparedQuery($sql, $connection, $collectionFactory);
         $cachedPreparedQuery->setCache($cache);

--- a/src/Ting/Query/QueryFactoryInterface.php
+++ b/src/Ting/Query/QueryFactoryInterface.php
@@ -37,7 +37,7 @@ interface QueryFactoryInterface
      * @param CollectionFactoryInterface $collectionFactory
      * @return Query
      */
-    public function get($sql, Connection $connection, CollectionFactoryInterface $collectionFactory = null);
+    public function get($sql, Connection $connection, ?CollectionFactoryInterface $collectionFactory = null);
 
     /**
      * @param string $sql
@@ -45,7 +45,7 @@ interface QueryFactoryInterface
      * @param CollectionFactoryInterface $collectionFactory
      * @return PreparedQuery
      */
-    public function getPrepared($sql, Connection $connection, CollectionFactoryInterface $collectionFactory = null);
+    public function getPrepared($sql, Connection $connection, ?CollectionFactoryInterface $collectionFactory = null);
 
     /**
      * @param string $sql
@@ -58,7 +58,7 @@ interface QueryFactoryInterface
         $sql,
         Connection $connection,
         Cache $cache,
-        CollectionFactoryInterface $collectionFactory = null
+        ?CollectionFactoryInterface $collectionFactory = null
     );
 
     /**
@@ -72,6 +72,6 @@ interface QueryFactoryInterface
         $sql,
         Connection $connection,
         Cache $cache,
-        CollectionFactoryInterface $collectionFactory = null
+        ?CollectionFactoryInterface $collectionFactory = null
     );
 }

--- a/src/Ting/Query/QueryInterface.php
+++ b/src/Ting/Query/QueryInterface.php
@@ -36,7 +36,7 @@ interface QueryInterface
      * @param Connection $connection
      * @param CollectionFactoryInterface $collectionFactory
      */
-    public function __construct($sql, Connection $connection, CollectionFactoryInterface $collectionFactory = null);
+    public function __construct($sql, Connection $connection, ?CollectionFactoryInterface $collectionFactory = null);
 
     /**
      * Execute a reading query (SELECT, SHOW, etc.)
@@ -46,7 +46,7 @@ interface QueryInterface
      *
      * @template T of object
      */
-    public function query(CollectionInterface $collection = null);
+    public function query(?CollectionInterface $collection = null);
 
     /**
      * Execute a writing query (UPDATE, INSERT, etc.)

--- a/src/Ting/Repository/Repository.php
+++ b/src/Ting/Repository/Repository.php
@@ -148,7 +148,7 @@ abstract class Repository
      *
      * @template U
      */
-    public function getCollection(HydratorInterface $hydrator = null)
+    public function getCollection(?HydratorInterface $hydrator = null)
     {
         return $this->collectionFactory->get($hydrator);
     }

--- a/src/Ting/Services.php
+++ b/src/Ting/Services.php
@@ -151,7 +151,7 @@ class Services implements ContainerInterface
         return $this;
     }
 
-    public function get($id, array $options = null)
+    public function get($id, ?array $options = null)
     {
         if ($options !== null) {
             if (isset($this->serviceOptions[$id]) && $this->serviceOptions[$id] !== $options) {


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets | ¤