### PR TITLE
Fix typing for factory

### DIFF
--- a/src/Ting/Repository/RepositoryFactory.php
+++ b/src/Ting/Repository/RepositoryFactory.php
@@ -102,9 +102,10 @@ class RepositoryFactory
     }
 
     /**
-     * @param class-string<Repository<T>> $repositoryName
-     * @return Repository<T>
+     * @param class-string<R> $repositoryName
+     * @return R
      * @template T of object
+     * @template R of Repository<T>
      */
     public function get($repositoryName)
     {


### PR DESCRIPTION
The current annotations are correct but not complete enough.

Since repositories extend a base class, they can have method that are not in this base class.

The issue with using `Repository<T>` as the return type is that PHPStan cannot see those methods.

For example: https://phpstan.org/r/65389bf5-b00d-4e5d-b993-8c6f274b7545

With this change, PHPStan understands the correct class while still forcing classes to extend `Repository`.

For example: https://phpstan.org/r/d40317b1-1834-407b-9284-ca1e7b0d3325

You can try removing the `@extends Repository<Foo>` or the `extends Repository` to see the correct errors.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0