### PR TITLE
fix: throw exception if pimple is missing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+3.10.5 (unreleased):
+    * Fix throws exception if Pimple is missing when using CCMBenchmark\Ting\Services
+
 3.10.4 (2025-01-17):
     * Fix HydratorRelational on null join where primary keys are public properties without default value
 

--- a/src/Ting/Services.php
+++ b/src/Ting/Services.php
@@ -36,6 +36,9 @@ class Services implements ContainerInterface
 
     public function __construct()
     {
+        if (!\class_exists(Container::class)) {
+            throw new \RuntimeException('pimple/pimple is required to use Ting services, please run "composer require pimple/pimple" to install it');
+        }
         $this->container = new Container();
         $this->container->offsetSet(
             'ConnectionPool',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets |

pimple/pimple has been moved from required to suggested dependencies in v3.10.0, however the  use of `CCMBenchmark\Ting\Services` will result in an PHP error. This MR throws a proper exception with instruction to explicitly install pimple.

poke @xavierleune 