### PR TITLE
Fix Driver Mysqli: you can now repeat a same parameter in your query

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+3.10.6 (unreleased):
+    * Fix Driver Mysqli: you can now repeat a same parameter in your query
+
 3.10.5 (2025-01-29):
     * Fix throws exception if Pimple is missing when using CCMBenchmark\Ting\Services
 

--- a/src/Ting/Driver/Mysqli/Driver.php
+++ b/src/Ting/Driver/Mysqli/Driver.php
@@ -355,7 +355,7 @@ class Driver implements DriverInterface
         $sql = preg_replace_callback(
             '/' . $this->parameterMatching . '/',
             function ($match) use (&$paramsOrder) {
-                $paramsOrder[$match[1]] = null;
+                $paramsOrder[] = $match[1];
                 return '?';
             },
             $sql

--- a/src/Ting/Driver/Mysqli/Statement.php
+++ b/src/Ting/Driver/Mysqli/Statement.php
@@ -76,7 +76,7 @@ class Statement implements StatementInterface
         $types = '';
         $values = [];
 
-        foreach (array_keys($this->paramsOrder) as $key) {
+        foreach ($this->paramsOrder as $key) {
             $value = $params[$key];
             $types .= self::PARAM_TYPE_BINDING[\gettype($value)] ?? 's';
 
@@ -86,7 +86,7 @@ class Statement implements StatementInterface
 
             $values[] = $value;
         }
-
+        
         $this->driverStatement->bind_param($types, ...$values);
 
         if ($this->logger !== null) {

--- a/tests/units/Ting/Driver/Mysqli/Statement.php
+++ b/tests/units/Ting/Driver/Mysqli/Statement.php
@@ -42,7 +42,7 @@ class Statement extends atoum
             'date'        => '2014-03-01 14:02:05',
             'is_banned'   => false,
         ];
-        $paramsOrder = ['firstname' => null, 'id' => null, 'description' => null, 'old' => null, 'date' => null, 'is_banned' => null];
+        $paramsOrder = ['firstname', 'id', 'description', 'old', 'date', 'is_banned'];
 
         $this->calling($driverStatement)->get_result = new \mock\Iterator();
         $driverStatement->errno = 0;


### PR DESCRIPTION
This kind of prepared query used to throw an error: `SELECT id FROM table WHERE (organization = :org AND user = :user) OR (organization = :org AND user is null)`. The issue came from using the parameter `org` twice, but it was only binded once for the current parsed statement: `SELECT id FROM table WHERE (organization = ? AND user = :user) OR (organization = ? AND user is null)`

PGSQL is not affected, because it used indexed parameters. The same query will be prepared as `SELECT id FROM table WHERE (organization = $1 AND user = :user) OR (organization = $1 AND user is null)`.

BTW I think that the method `__construct` should be removed from the `CCMBenchmark\Ting\Driver\StatementInterface`, as it may be specific per driver, it would allow better type hints / phpdoc on that part.


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets | ¤