### PR TITLE
feature: prevent entity listener serialization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 3.12.0 (unreleased):
     * add __debuginfo() in NotifyInterface to reduce context when dumping an entity
     * Driver now supports reconnect, useful in forked processes
+    * Prevent entity listeners serialization
 
 3.11.0 (2025-03.14):
     * Fix Driver Mysqli: mysqli_ping has no effect since PHP 8.2, fix that.

--- a/src/Ting/Entity/NotifyProperty.php
+++ b/src/Ting/Entity/NotifyProperty.php
@@ -63,4 +63,12 @@ trait NotifyProperty
 
         return $properties;
     }
+
+    public function __serialize(): array
+    {
+        $properties = get_object_vars($this);
+        unset($properties['listeners']);
+
+        return $properties;
+    }
 }

--- a/tests/units/Ting/Entity/NotifyProperty.php
+++ b/tests/units/Ting/Entity/NotifyProperty.php
@@ -26,6 +26,7 @@
 namespace tests\units\CCMBenchmark\Ting\Entity;
 
 use atoum;
+use tests\fixtures\model\Bouh;
 
 class NotifyProperty extends atoum
 {
@@ -61,6 +62,36 @@ class NotifyProperty extends atoum
             ->mock($mockListener2)
                 ->call('propertyChanged')
                     ->once()
+        ;
+    }
+
+    public function testSerializationWithoutListerners()
+    {
+        $mockListener  = new \mock\CCMBenchmark\Ting\Entity\PropertyListenerInterface();
+        $mockListener2 = new \mock\CCMBenchmark\Ting\Entity\PropertyListenerInterface();
+        $entity = new Bouh();
+        $entity->setId(20);
+        $entity->setName('Xavier');
+        $entity->addPropertyListener($mockListener);
+        $entity->addPropertyListener($mockListener2);
+
+        var_dump($entity);
+
+        $expected = [
+            'id' => 20,
+            'firstname' => null,
+            'name' => 'Xavier',
+            'enabled' => null,
+            'price' => null,
+            'roles' => ['USER'],
+            'city' => null,
+            'retrievedTime' => null,
+            'originalCity' => null,
+            'cities' => [],
+        ];
+        $this
+            ->array($serialized = $entity->__serialize())
+            ->isIdenticalTo($expected)
         ;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets | N/A

Avoid serialization of listeners, this would avoid serializing parts of symfony stack.