### PR TITLE
Driver now supports reconnect, useful in forked processes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 3.12.0 (unreleased):
     * add __debuginfo() in NotifyInterface to reduce context when dumping an entity
+    * Driver now supports reconnect, useful in forked processes
 
 3.11.0 (2025-03.14):
     * Fix Driver Mysqli: mysqli_ping has no effect since PHP 8.2, fix that.

--- a/src/Ting/Driver/Mysqli/Driver.php
+++ b/src/Ting/Driver/Mysqli/Driver.php
@@ -514,23 +514,7 @@ class Driver implements DriverInterface
             }
         } catch (mysqli_sql_exception) { }
 
-        try {
-            $this->createConnection();
-            $this->connected = $this->connection->real_connect($this->connectionConfig['hostname'], $this->connectionConfig['username'], $this->connectionConfig['password'], $this->currentDatabase, $this->connectionConfig['port']);
-
-            if ($this->currentCharset !== null) {
-                $this->connection->set_charset($this->currentCharset);
-            }
-
-            if ($this->currentTimezone !== null) {
-                $this->connection->query(sprintf('SET time_zone = "%s";', $this->currentTimezone));
-            }
-            $this->oldPreparedQueries = array_merge($this->preparedQueries, $this->oldPreparedQueries);
-            $this->preparedQueries = [];
-            return true;
-        } catch (\Exception $e) {
-            return false;
-        }
+        return $this->reconnect();
     }
 
     /**
@@ -556,5 +540,26 @@ class Driver implements DriverInterface
     {
         $this->connection = mysqli_init();
         $this->connection->options(MYSQLI_OPT_INT_AND_FLOAT_NATIVE, 1);
+    }
+
+    public function reconnect(): bool
+    {
+        try {
+            $this->createConnection();
+            $this->connected = $this->connection->real_connect($this->connectionConfig['hostname'], $this->connectionConfig['username'], $this->connectionConfig['password'], $this->currentDatabase, $this->connectionConfig['port']);
+
+            if ($this->currentCharset !== null) {
+                $this->connection->set_charset($this->currentCharset);
+            }
+
+            if ($this->currentTimezone !== null) {
+                $this->connection->query(sprintf('SET time_zone = "%s";', $this->currentTimezone));
+            }
+            $this->oldPreparedQueries = array_merge($this->preparedQueries, $this->oldPreparedQueries);
+            $this->preparedQueries = [];
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 }

--- a/src/Ting/Driver/Pgsql/Driver.php
+++ b/src/Ting/Driver/Pgsql/Driver.php
@@ -525,4 +525,23 @@ class Driver implements DriverInterface
         pg_query($this->connection, sprintf($query, $value));
         $this->currentTimezone = $timezone;
     }
+    public function reconnect(): bool
+    {
+        $this->connection = null;
+        try {
+            $this->setDatabase($this->database);
+            if ($this->currentTimezone !== null) {
+                $tz = $this->currentTimezone;
+                $this->currentTimezone = null;
+                $this->setTimezone($tz);
+            }
+            if ($this->currentCharset !== null) {
+                $charset = $this->currentCharset;
+                $this->currentCharset = null;
+                $this->setCharset($charset);
+            }
+        } catch (DriverException) {
+            return false;
+        }
+    }
 }

--- a/src/Ting/Repository/CollectionInterface.php
+++ b/src/Ting/Repository/CollectionInterface.php
@@ -42,7 +42,7 @@ interface CollectionInterface extends \IteratorAggregate, \Countable
     public function set(ResultInterface $result);
 
     /**
-     * @return T
+     * @return T|null
      */
     public function first();
 


### PR DESCRIPTION
When you fork a process in PHP, all objects are copied in the memory for the new process, but references they hold to resources are kept intact.
When you start interacting with the database in a forked context, the underlying mysqli connection is untouched ; so you can get the results coming from another fork.
This pull requests adds a "reconnect" method to the driver, to recreate the underlying connections and happily query your database without further issues !

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets | 