### PR TITLE
fix: phpstan generic error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
     * Driver now supports reconnect, useful in forked processes
     * Prevent entity listeners serialization
     * bump aura/sqlquery to 3.0.0
+    * Fix generics for phpstan on MetadataInitializer interface
 
 3.11.0 (2025-03.14):
     * Fix Driver Mysqli: mysqli_ping has no effect since PHP 8.2, fix that.

--- a/src/Ting/Repository/MetadataInitializer.php
+++ b/src/Ting/Repository/MetadataInitializer.php
@@ -30,9 +30,10 @@ use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 interface MetadataInitializer
 {
     /**
+     * @template M of \CCMBenchmark\Ting\Repository\Metadata
      * @param  SerializerFactoryInterface $serializerFactory
      * @param  array                      $options
-     * @return \CCMBenchmark\Ting\Repository\Metadata
+     * @return M
      */
     public static function initMetadata(SerializerFactoryInterface $serializerFactory, array $options = []);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets | 

Avoids the following Phpstan error :
> Method <A repository>::initMetadata() return type with generic class CCMBenchmark\Ting\Repository\Metadata does not specify its types: T