### PR TITLE
fix: avoid notice on return types for \Iterator implementations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
     * Prevent entity listeners serialization
     * bump aura/sqlquery to 3.0.0
     * Fix generics for phpstan on MetadataInitializer interface
+    * fix notice on \iterator implementations
 
 3.11.0 (2025-03.14):
     * Fix Driver Mysqli: mysqli_ping has no effect since PHP 8.2, fix that.

--- a/src/Ting/Driver/CacheResult.php
+++ b/src/Ting/Driver/CacheResult.php
@@ -92,8 +92,7 @@ class CacheResult implements ResultInterface
     /**
      * Iterator
      */
-    #[\ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
         if ($this->result !== null) {
             $this->result->rewind();
@@ -102,10 +101,8 @@ class CacheResult implements ResultInterface
 
     /**
      * Return current row
-     * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
-    public function current()
+    public function current(): mixed
     {
         if ($this->result === null) {
             return null;
@@ -116,10 +113,8 @@ class CacheResult implements ResultInterface
 
     /**
      * Return the key of the actual row
-     * @return int|mixed
      */
-    #[\ReturnTypeWillChange]
-    public function key()
+    public function key(): mixed
     {
         if ($this->result === null) {
             return null;
@@ -131,8 +126,7 @@ class CacheResult implements ResultInterface
     /**
      * Move to the next row in result set
      */
-    #[\ReturnTypeWillChange]
-    public function next()
+    public function next(): void
     {
         if ($this->result !== null) {
             $this->result->next();
@@ -141,10 +135,8 @@ class CacheResult implements ResultInterface
 
     /**
      * Is the actual row valid
-     * @return bool
      */
-    #[\ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         if ($this->result === null) {
             return false;

--- a/src/Ting/Driver/Mysqli/Result.php
+++ b/src/Ting/Driver/Mysqli/Result.php
@@ -177,8 +177,7 @@ class Result implements ResultInterface
      *  select * from city c inner join country co on (c.cou_code = co.cou_code)
      *  the second column "cou_code" is missing, cause current() use an associative array
      */
-    #[\ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
         if ($this->result !== null) {
             $this->result->data_seek(0);
@@ -189,20 +188,16 @@ class Result implements ResultInterface
 
     /**
      * Return current row
-     * @return mixed|null
      */
-    #[\ReturnTypeWillChange]
-    public function current()
+    public function current(): mixed
     {
         return $this->iteratorCurrent;
     }
 
     /**
      * Return the key of the actual row
-     * @return int|mixed
      */
-    #[\ReturnTypeWillChange]
-    public function key()
+    public function key(): mixed
     {
         return $this->iteratorOffset;
     }
@@ -210,8 +205,7 @@ class Result implements ResultInterface
     /**
      * Move to the next row in result set
      */
-    #[\ReturnTypeWillChange]
-    public function next()
+    public function next(): void
     {
         if ($this->result !== null) {
             $this->iteratorCurrent = $this->format($this->result->fetch_array(MYSQLI_NUM));
@@ -224,8 +218,7 @@ class Result implements ResultInterface
      * Is the actual row valid
      * @return bool
      */
-    #[\ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         return $this->iteratorCurrent !== null;
     }

--- a/src/Ting/Driver/Pgsql/Result.php
+++ b/src/Ting/Driver/Pgsql/Result.php
@@ -342,35 +342,30 @@ class Result implements ResultInterface
     /**
      * Iterator
      */
-    #[\ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
         $this->dataSeek(0);
         $this->iteratorOffset = -1;
         $this->next();
     }
 
-    #[\ReturnTypeWillChange]
-    public function current()
+    public function current(): mixed
     {
         return $this->iteratorCurrent;
     }
 
-    #[\ReturnTypeWillChange]
-    public function key()
+    public function key(): mixed
     {
         return $this->iteratorOffset;
     }
 
-    #[\ReturnTypeWillChange]
-    public function next()
+    public function next(): void
     {
         $this->iteratorCurrent = $this->format(pg_fetch_array($this->result, null, \PGSQL_NUM));
         $this->iteratorOffset++;
     }
 
-    #[\ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         return $this->iteratorCurrent !== null;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets | 