### PR TITLE
feature: add value object hydrator

### DIFF
--- a/src/Ting/Driver/Pgsql/Driver.php
+++ b/src/Ting/Driver/Pgsql/Driver.php
@@ -540,6 +540,7 @@ class Driver implements DriverInterface
                 $this->currentCharset = null;
                 $this->setCharset($charset);
             }
+            return true;
         } catch (DriverException) {
             return false;
         }

--- a/src/Ting/Repository/HydratorValueObject.php
+++ b/src/Ting/Repository/HydratorValueObject.php
@@ -1,0 +1,136 @@
+<?php
+
+/***********************************************************************
+ *
+ * Ting - PHP Datamapper
+ * ==========================================
+ *
+ * Copyright (C) 2014 CCM Benchmark Group. (http://www.ccmbenchmark.com)
+ *
+ ***********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ **********************************************************************/
+
+namespace CCMBenchmark\Ting\Repository;
+
+use CCMBenchmark\Ting\Driver\ResultInterface;
+use CCMBenchmark\Ting\MetadataRepository;
+use CCMBenchmark\Ting\UnitOfWork;
+use CCMBenchmark\Ting\Util\PropertyAccessor;
+use DateTime;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+use function reset;
+
+/**
+ * @template T
+ *
+ * @template-implements HydratorInterface<T>
+ */
+class HydratorValueObject implements HydratorInterface
+{
+    /**
+     * @var class-string<T>
+     */
+    protected $objectToHydrate;
+    /**
+     * @var PropertyAccessor
+     */
+    protected $propertyAccessor;
+    /**
+     * @var ResultInterface<T>
+     */
+    protected $result = null;
+
+    /**
+     * @param class-string<T> $objectToHydrate
+     */
+    public function __construct(string $objectToHydrate)
+    {
+        $this->objectToHydrate = $objectToHydrate;
+        $this->propertyAccessor = new PropertyAccessor();
+    }
+
+    /**
+     * @param MetadataRepository $metadataRepository
+     * @return void
+     */
+    public function setMetadataRepository(MetadataRepository $metadataRepository)
+    {
+        // Useless for this hydrator
+    }
+
+    /**
+     * @param UnitOfWork $unitOfWork
+     * @return void
+     */
+    public function setUnitOfWork(UnitOfWork $unitOfWork)
+    {
+        // Useless for this hydrator
+    }
+
+    /**
+     * @param ResultInterface<T> $result
+     * @return $this
+     */
+    public function setResult(ResultInterface $result)
+    {
+        $this->result = $result;
+        return $this;
+    }
+
+    /**
+     * @return \Generator<int, T>
+     */
+    #[\ReturnTypeWillChange]
+    public function getIterator()
+    {
+        foreach ($this->result as $key => $row) {
+            yield $key => $this->hydrateColumns($row);
+        }
+    }
+
+    /**
+     * @return int
+     */
+    #[\ReturnTypeWillChange]
+    public function count()
+    {
+        if ($this->result === null) {
+            return 0;
+        }
+
+        return $this->result->getNumRows();
+    }
+
+    private function hydrateColumns(array $rows)
+    {
+        $object = new $this->objectToHydrate();
+        foreach ($rows as $column) {
+            $reflectionData = $this->propertyAccessor->getReflectionData($object, $column['name']);
+            if (in_array($reflectionData['type'], ['DateTime', 'DateTimeImmutable'])) {
+                $column['value'] = new $reflectionData['type']($column['value']);
+            }
+            $this->propertyAccessor->setValue($object, $column['name'], $column['value']);
+        }
+
+        return $object;
+    }
+
+    private function getSerializerFromType(string $type)
+    {
+
+    }
+}

--- a/src/Ting/Util/PropertyAccessor.php
+++ b/src/Ting/Util/PropertyAccessor.php
@@ -76,7 +76,7 @@ class PropertyAccessor
      * @throws \Psr\Cache\InvalidArgumentException
      * @throws \ReflectionException
      */
-    private function getReflectionData(object $object, string $propertyPath): array
+    public function getReflectionData(object $object, string $propertyPath): array
     {
         $key = \get_class($object).'..'.$propertyPath;
         if (isset($this->reflectionData[$key])) {
@@ -95,6 +95,8 @@ class PropertyAccessor
             'public' => $reflection->isPublic(),
             'supportsHook' => \PHP_VERSION_ID >= 80400,
             'hasSetHook' => \PHP_VERSION_ID >= 80400 && $reflection->getHook(\PropertyHookType::Set) !== null,
+            'type' => $reflection->getType()?->getName(),
+            'nullable' => $reflection->getType() !== null && $reflection->getType()->allowsNull()
         ];
 
         if (isset($item)) {

--- a/tests/fixtures/ValueObject/Bouh.php
+++ b/tests/fixtures/ValueObject/Bouh.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace tests\fixtures\ValueObject;
+
+class Bouh
+{
+    private $firstname;
+
+    private $name;
+
+    /**
+     * @return mixed
+     */
+    public function getFirstname()
+    {
+        return $this->firstname;
+    }
+
+    public function setFirstname($firstname)
+    {
+        $this->firstname = $firstname;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/fixtures/ValueObject/BouhWithNativeType.php
+++ b/tests/fixtures/ValueObject/BouhWithNativeType.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace tests\fixtures\ValueObject;
+
+class BouhWithNativeType
+{
+    private int $nb;
+
+    private float $avg;
+
+    private string $name;
+
+    private \DateTime $date;
+
+    private \DateTimeImmutable $dateTimeImmutable;
+
+    private bool $bool;
+
+    public function getNb(): int
+    {
+        return $this->nb;
+    }
+
+    public function setNb(int $nb): void
+    {
+        $this->nb = $nb;
+    }
+
+    public function getAvg(): float
+    {
+        return $this->avg;
+    }
+
+    public function setAvg(float $avg): void
+    {
+        $this->avg = $avg;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getDate(): \DateTime
+    {
+        return $this->date;
+    }
+
+    public function setDate(\DateTime $date): void
+    {
+        $this->date = $date;
+    }
+
+    public function getDateTimeImmutable(): \DateTimeImmutable
+    {
+        return $this->dateTimeImmutable;
+    }
+
+    public function setDateTimeImmutable(\DateTimeImmutable $dateTimeImmutable): void
+    {
+        $this->dateTimeImmutable = $dateTimeImmutable;
+    }
+
+    public function isBool(): bool
+    {
+        return $this->bool;
+    }
+
+    public function setBool(bool $bool): void
+    {
+        $this->bool = $bool;
+    }
+}

--- a/tests/fixtures/ValueObject/WrongObject.php
+++ b/tests/fixtures/ValueObject/WrongObject.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace tests\fixtures\ValueObject;
+
+class WrongObject
+{
+    private $wrong;
+
+    /**
+     * @return mixed
+     */
+    public function getWrong()
+    {
+        return $this->wrong;
+    }
+
+    /**
+     * @param mixed $wrong
+     */
+    public function setWrong($wrong): void
+    {
+        $this->wrong = $wrong;
+    }
+}

--- a/tests/units/Ting/Entity/NotifyProperty.php
+++ b/tests/units/Ting/Entity/NotifyProperty.php
@@ -75,8 +75,6 @@ class NotifyProperty extends atoum
         $entity->addPropertyListener($mockListener);
         $entity->addPropertyListener($mockListener2);
 
-        var_dump($entity);
-
         $expected = [
             'id' => 20,
             'firstname' => null,

--- a/tests/units/Ting/Repository/HydratorValueObject.php
+++ b/tests/units/Ting/Repository/HydratorValueObject.php
@@ -1,0 +1,198 @@
+<?php
+
+/***********************************************************************
+ *
+ * Ting - PHP Datamapper
+ * ==========================================
+ *
+ * Copyright (C) 2014 CCM Benchmark Group. (http://www.ccmbenchmark.com)
+ *
+ ***********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ **********************************************************************/
+
+namespace tests\units\CCMBenchmark\Ting\Repository;
+
+use CCMBenchmark\Ting\Driver\Mysqli\Result;
+use atoum;
+use ReflectionException;
+use tests\fixtures\ValueObject\Bouh;
+use tests\fixtures\ValueObject\BouhWithNativeType;
+use tests\fixtures\ValueObject\WrongObject;
+
+class HydratorValueObject extends atoum
+{
+    public function testHydrateShouldReturnBouhObject()
+    {
+        $mockMysqliResult = new \mock\tests\fixtures\FakeDriver\MysqliResult([['Sylvain', 'Robez-Masson']]);
+        $this->calling($mockMysqliResult)->fetch_fields = function () {
+            $fields = [];
+            $stdClass = new \stdClass();
+            $stdClass->name     = 'firstname';
+            $stdClass->orgname  = 'boo_firstname';
+            $stdClass->table    = 'bouh';
+            $stdClass->orgtable = 'T_BOUH_BOO';
+            $stdClass->type     = MYSQLI_TYPE_VAR_STRING;
+            $fields[] = $stdClass;
+
+            $stdClass = new \stdClass();
+            $stdClass->name     = 'name';
+            $stdClass->orgname  = 'boo_name';
+            $stdClass->table    = 'bouh';
+            $stdClass->orgtable = 'T_BOUH_BOO';
+            $stdClass->type     = MYSQLI_TYPE_VAR_STRING;
+            $fields[] = $stdClass;
+            return $fields;
+        };
+
+        $result = new Result();
+        $result->setResult($mockMysqliResult);
+        $result->setConnectionName('connectionName');
+        $result->setDatabase('database');
+
+        $this
+            ->if($hydrator = new \CCMBenchmark\Ting\Repository\HydratorValueObject(Bouh::class))
+            ->then($iterator = $hydrator->setResult($result)->getIterator())
+            ->then($bouh = $iterator->current())
+            ->object($bouh)
+                ->isInstanceOf('tests\fixtures\ValueObject\Bouh')
+            ->string($bouh->getName())
+                ->isIdenticalTo('Robez-Masson')
+            ->string($bouh->getFirstname())
+                ->isIdenticalTo('Sylvain');
+    }
+
+    public function testHydrateShouldSupportNativeTypes()
+    {
+        $mockMysqliResult = new \mock\tests\fixtures\FakeDriver\MysqliResult([[1, 4.2, 'Robez-Masson', '2025-01-01 00:00:00'/*, '2025-02-28 13:37:42'*/, 0]]);
+        $this->calling($mockMysqliResult)->fetch_fields = function () {
+            $fields = [];
+            $stdClass = new \stdClass();
+            $stdClass->name     = 'nb';
+            $stdClass->orgname  = 'boo_nb';
+            $stdClass->table    = 'bouh';
+            $stdClass->orgtable = 'T_BOUH_BOO';
+            $stdClass->type     = MYSQLI_TYPE_INT24;
+            $fields[] = $stdClass;
+
+            $stdClass = new \stdClass();
+            $stdClass->name     = 'avg';
+            $stdClass->orgname  = 'boo_avg';
+            $stdClass->table    = 'bouh';
+            $stdClass->orgtable = 'T_BOUH_BOO';
+            $stdClass->type     = MYSQLI_TYPE_DECIMAL;
+            $fields[] = $stdClass;
+
+            $stdClass = new \stdClass();
+            $stdClass->name     = 'name';
+            $stdClass->orgname  = 'boo_name';
+            $stdClass->table    = 'bouh';
+            $stdClass->orgtable = 'T_BOUH_BOO';
+            $stdClass->type     = MYSQLI_TYPE_VAR_STRING;
+            $fields[] = $stdClass;
+
+            $stdClass = new \stdClass();
+            $stdClass->name     = 'date';
+            $stdClass->orgname  = 'boo_date';
+            $stdClass->table    = 'bouh';
+            $stdClass->orgtable = 'T_BOUH_BOO';
+            $stdClass->type     = MYSQLI_TYPE_DATETIME;
+            $fields[] = $stdClass;
+//
+//            $stdClass = new \stdClass();
+//            $stdClass->name     = 'dateimmutable';
+//            $stdClass->orgname  = 'boo_dateimmutable';
+//            $stdClass->table    = 'bouh';
+//            $stdClass->orgtable = 'T_BOUH_BOO';
+//            $stdClass->type     = MYSQLI_TYPE_DATETIME;
+//            $fields[] = $stdClass;
+
+            $stdClass = new \stdClass();
+            $stdClass->name     = 'bool';
+            $stdClass->orgname  = 'boo_bool';
+            $stdClass->table    = 'bouh';
+            $stdClass->orgtable = 'T_BOUH_BOO';
+            $stdClass->type     = MYSQLI_TYPE_INT24;
+            $fields[] = $stdClass;
+
+            return $fields;
+        };
+
+        $result = new Result();
+        $result->setResult($mockMysqliResult);
+        $result->setConnectionName('connectionName');
+        $result->setDatabase('database');
+
+        $this
+            ->if($hydrator = new \CCMBenchmark\Ting\Repository\HydratorValueObject(BouhWithNativeType::class))
+            ->then($iterator = $hydrator->setResult($result)->getIterator())
+            ->then($bouh = $iterator->current())
+            ->object($bouh)
+            ->isInstanceOf('tests\fixtures\ValueObject\BouhWithNativeType')
+        ;
+    }
+
+    public function testHydrateShouldThrowAnExceptionWhenResultAndObjectDoNotMatch()
+    {
+        $mockMysqliResult = new \mock\tests\fixtures\FakeDriver\MysqliResult([['Sylvain', 'Robez-Masson']]);
+        $this->calling($mockMysqliResult)->fetch_fields = function () {
+            $fields = [];
+            $stdClass = new \stdClass();
+            $stdClass->name     = 'firstname';
+            $stdClass->orgname  = 'boo_firstname';
+            $stdClass->table    = 'bouh';
+            $stdClass->orgtable = 'T_BOUH_BOO';
+            $stdClass->type     = MYSQLI_TYPE_VAR_STRING;
+            $fields[] = $stdClass;
+
+            $stdClass = new \stdClass();
+            $stdClass->name     = 'name';
+            $stdClass->orgname  = 'boo_name';
+            $stdClass->table    = 'bouh';
+            $stdClass->orgtable = 'T_BOUH_BOO';
+            $stdClass->type     = MYSQLI_TYPE_VAR_STRING;
+            $fields[] = $stdClass;
+            return $fields;
+        };
+
+        $result = new Result();
+        $result->setResult($mockMysqliResult);
+        $result->setConnectionName('connectionName');
+        $result->setDatabase('database');
+
+        $this
+            ->if($hydrator = new \CCMBenchmark\Ting\Repository\HydratorValueObject(WrongObject::class))
+            ->and($iterator = $hydrator->setResult($result)->getIterator())
+            ->exception(function () use ($iterator) {
+                $var =  $iterator->current();
+            })
+            ->isInstanceOf(ReflectionException::class)
+        ;
+    }
+
+
+    public function testCountShouldReturn2()
+    {
+        $result = new \mock\CCMBenchmark\Ting\Driver\Mysqli\Result();
+
+        $this->calling($result)->getNumRows = 2;
+
+        $this
+            ->if($hydrator = new \CCMBenchmark\Ting\Repository\HydratorSingleObject())
+            ->then($hydrator->setResult($result))
+            ->integer($hydrator->count())
+            ->isIdenticalTo(2);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Licence       | Apache-2.0
| Fixed tickets | 

This PR adds support for non-entity anemic objects hydration.

```php
$this->getQuery($queryBuilder)
     ->setParams($queryBuilder->getBindValues())
     ->query($this->getCollection(new HydratorObject(MyAnemicObject::class)));
```

:warning: This is still a work in progress !